### PR TITLE
Tidy readme's and docs index naming convention

### DIFF
--- a/.pip_readme.rst
+++ b/.pip_readme.rst
@@ -14,7 +14,7 @@
 S2FFT: JAX accelerated spin-spherical harmonic transforms
 =================================================================================================================
 
-Add some basic discussion about ``<project-name>`` here.
+Add some basic discussion about ``S2FFT`` here.
 
 Installation
 ============
@@ -36,7 +36,7 @@ A BibTeX entry for <project-name> is:
 
 .. code-block:: 
 
-     @article{<project-name>, 
+     @article{S2FFT, 
         author = {Author~List},
          title = {"A totally amazing name"},
        journal = {ArXiv},
@@ -47,15 +47,11 @@ A BibTeX entry for <project-name> is:
 License
 =======
 
-``<project-name>`` is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/code_template/blob/main/LICENCE.txt>`_).
+``S2FFT`` is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/s2fft/blob/main/LICENCE.txt>`_).
 
 .. code-block::
 
      S2fft
      Copyright (C) 2022 Author names & contributors
 
-     This program is released under the MIT license (see LICENCE.txt).
-
-     This program is distributed in the hope that it will be useful,
-     but WITHOUT ANY WARRANTY; without even the implied warranty of
-     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+     This program is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/s2fft/blob/main/LICENCE.txt>`_).

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 S2fft
+Copyright (c) 2022 Authors & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -18,13 +18,12 @@
 
    <img src="./docs/assets/placeholder_logo.png" align="center" height="80" width="80">
 
-This is a very loose framework for people to start python projects from. To get up and running, go through the code carefully replacing ``Project-name`` with your 
-desired project name (check all documents!), don't forget to change the directory s2fft as well! You will also need to update the links in all badges!
+A description of the overall software package.
 
 Installation
 ============
 
-The Python dependencies for the `s2fft` package are listed in the file ``requirements/requirements-core.txt`` and can be installed 
+The Python dependencies for the ``S2FFT`` package are listed in the file ``requirements/requirements-core.txt`` and can be installed 
 into the active Python environment using `pip` by running
 
 .. code-block:: bash 
@@ -33,7 +32,7 @@ into the active Python environment using `pip` by running
     
 from the root directory of the repository.
     
-To install the `s2fft` package in editable mode in the current Python environment run
+To install the ``S2FFT`` package in editable mode in the current Python environment run
 
 .. code-block:: bash
     
@@ -93,69 +92,24 @@ Interface
 
 Temporary notes on interface to be updated.
 
-flm = forward_transform(f, L, sampling, reality, implementation)
-f = inverse_transform(flm, sampling, reality, implementation, nside=None)
+.. code-block:: python
 
-sampling = {"mw", "mwss", "healpix"}; default = mw
-reality = {"real", "complex"}; default = complex
-implementation = {"loopy", "vectorized", "jax"}; default = jax
-nside default = None
+    flm = forward_transform(f, L, sampling, reality, implementation)
+    f = inverse_transform(flm, sampling, reality, implementation, nside=None)
 
+    sampling = {"mw", "mwss", "healpix"}; default = mw
+    reality = {"real", "complex"}; default = complex
+    implementation = {"loopy", "vectorized", "jax"}; default = jax
+    nside default = None
 
-
-Auto-formatting code
-====================
-To keep the code readable and organised you should (strongly) consider using the ``black`` package. Whenever you are finished updating a file, just run 
-
-.. code-block:: bash
-
-    black <file_to_tidy.py>
-
-or alternatively format everything by running
-
-.. code-block:: bash
-
-    black s2fft/*
-
-This is important as the CI enforces black formatting (this can be disabled by removing the --black flag in pytest) so your unit tests will fail if you don't do this!
-
-CodeCov
-============
-To set up code coverage you will need to enter this  
-
-.. code-block:: bash
-
-    https://codecov.io/gh/{account-name}/{desired-repo} 
-
-into any browser, then go to settings and activate the repository. You will then need to find the ``repository upload token`` which 
-should be added to the github actions script (roughly line 29)
-
-.. code-block::
-
-    codecov --token <add your token here>
-
-Next time CI runs on main branch it will automatically update codecov. Now go back to codecov, copy the badge and put it in the readme, .pipreadme, and 
-the root index of the documentation!
-
-PyPi
-=====
-To deploy the code on PyPi first test the deployment on PyPi's mirror site by, first making an account on https://test.pypi.org and then running 
-
-.. code-block:: bash 
-
-    python setup.py bdist_wheel --universal
-    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-    pip install -i https://test.pypi.org/simple/ s2fft
-
-From the root directory. Keep in mind that installing from the mirror site won't automatically find dependencies, so if you have an error because the pacakge can't find numpy that's probably why, and may not be an issue on the main PyPi site. To deploy the main PyPi site simply remove the --repostiry-url name, note that you can add multiple wheels to dist/*, to provide a package which may be pip installed for multiple python version, and on multiple machine architectures.
 
 Attribution
 ===========
-A BibTeX entry for <project-name> is:
+A BibTeX entry for ``S2FFT`` is:
 
 .. code-block:: 
 
-     @article{<project-name>, 
+     @article{S2FFT, 
         author = {Author~List},
          title = {"A totally amazing name"},
        journal = {ArXiv},
@@ -166,15 +120,11 @@ A BibTeX entry for <project-name> is:
 License
 =======
 
-``<project-name>`` is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/code_template/blob/main/LICENCE.txt>`_).
+``S2FFT`` is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/s2fft/blob/main/LICENCE.txt>`_).
 
 .. code-block::
 
      S2fft
      Copyright (C) 2022 Author names & contributors
 
-     This program is released under the MIT license (see LICENCE.txt).
-
-     This program is distributed in the hope that it will be useful,
-     but WITHOUT ANY WARRANTY; without even the implied warranty of
-     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+     This program is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/s2fft/blob/main/LICENCE.txt>`_).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@
 S2FFT: JAX accelerated spin-spherical harmonic transforms
 =================================================================================================================
 
-Add some basic discussion about ``<project-name>`` here.
+Add some basic discussion about ``S2FFT`` here.
 
 Installation
 ============
@@ -34,11 +34,11 @@ Author names & Contributors
 
 Attribution
 ===========
-A BibTeX entry for <project-name> is:
+A BibTeX entry for ``S2FFT`` is:
 
 .. code-block:: 
 
-     @article{<project-name>, 
+     @article{S2FFT, 
         author = {Author~List},
          title = {"A totally amazing name"},
        journal = {ArXiv},
@@ -49,18 +49,14 @@ A BibTeX entry for <project-name> is:
 License
 =======
 
-``<project-name>`` is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/code_template/blob/main/LICENCE.txt>`_).
+``S2FFT`` is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/s2fft/blob/main/LICENCE.txt>`_).
 
 .. code-block::
 
      S2fft
      Copyright (C) 2022 Author names & contributors
 
-     This program is released under the MIT license (see LICENCE.txt).
-
-     This program is distributed in the hope that it will be useful,
-     but WITHOUT ANY WARRANTY; without even the implied warranty of
-     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+     This program is released under the MIT license (see `LICENSE.txt <https://github.com/astro-informatics/s2fft/blob/main/LICENCE.txt>`_).
 
 .. bibliography:: 
     :notcited:


### PR DESCRIPTION
Closes #75 

Cleans up some of the naming conventions outlined in issue #75. There is more to be done, but this is a larger PR to come once the core package is complete, pre-release.