### PR TITLE
Debug

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - name: Checkout Source
@@ -28,11 +28,14 @@ jobs:
       run: |
         sudo apt install pandoc
         python -m pip install --upgrade pip
-        python -m pip install tox
+        pip install -r requirements/requirements-tests.txt
+        pip install -r requirements/requirements-core.txt
+        pip install -r requirements/requirements-docs.txt
+        pip install .
   
     - name: Build Documentation
       run: |
-        tox -e docs
+        cd docs && make html
 
     - name: Deploy
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - name: Checkout Source
@@ -28,9 +28,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox
+        pip install -r requirements/requirements-tests.txt
+        pip install -r requirements/requirements-core.txt
+        pip install .
     
     - name: Run tests
       run: |
-        tox -e py38
-        tox -e codecov -- --token 298dc7ee-bb9f-4221-b31f-3576cc6cb702
+        pytest --cov-report term --cov=s2wav --cov-config=.coveragerc 
+        codecov --token 298dc7ee-bb9f-4221-b31f-3576cc6cb702

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -1,6 +1,7 @@
 # Testing
 pytest 
 pytest-cov
+codecov
 
 #jax dependencies
 jaxlib

--- a/s2fft/recursions/price_mcewen.py
+++ b/s2fft/recursions/price_mcewen.py
@@ -242,8 +242,9 @@ def generate_precomputes_jax(
     indices = jnp.repeat(jnp.expand_dims(jnp.arange(L0, L), 0), ntheta, axis=0)
 
     # Remove redundant nans:
-    # - forward pass these are not accessed, so are irrelevant.
-    # - backward pass the adjoint computation accumulates these nans into grads.
+    # - in forward pass these are not accessed, so are irrelevant.
+    # - in backward pass the adjoint computation otherwise accumulates these 
+    #   nans into grads if not set to zero.
     lrenorm = jnp.nan_to_num(lrenorm, nan=0.0, posinf=0.0, neginf=0.0)
     cpi = jnp.nan_to_num(cpi, nan=0.0, posinf=0.0, neginf=0.0)
     cp2 = jnp.nan_to_num(cp2, nan=0.0, posinf=0.0, neginf=0.0)

--- a/s2fft/recursions/price_mcewen.py
+++ b/s2fft/recursions/price_mcewen.py
@@ -241,6 +241,13 @@ def generate_precomputes_jax(
 
     indices = jnp.repeat(jnp.expand_dims(jnp.arange(L0, L), 0), ntheta, axis=0)
 
+    # Remove redundant nans:
+    # - forward pass these are not accessed, so are irrelevant.
+    # - backward pass the adjoint computation accumulates these nans into grads.
+    lrenorm = jnp.nan_to_num(lrenorm, nan=0.0, posinf=0.0, neginf=0.0)
+    cpi = jnp.nan_to_num(cpi, nan=0.0, posinf=0.0, neginf=0.0)
+    cp2 = jnp.nan_to_num(cp2, nan=0.0, posinf=0.0, neginf=0.0)
+
     return [lrenorm, vsign, cpi, cp2, indices]
 
 


### PR DESCRIPTION
Fixes some floating bugs which are causing downstream issues.

- [x] Remove tox from CI as docs keep failing to link correctly (solution isn't as elegant but should hopefully be more robust).
- [x] Switch CI from py38 to py39.
- [x] Explicitly null undefined values in jax pre computations (not an issue for forward pass, but for certain transforms when executing auto-grad these undefined values are folded into the adjoint computation, causing gradients to become undefined in some cases).