### PR TITLE
Feature/custom grads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,14 +25,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     
-    # - name: Install dependencies
-    #   run: |
-    #     python -m pip install --upgrade pip
-    #     pip install -r requirements/requirements-tests.txt
-    #     pip install -r requirements/requirements-core.txt
-    #     pip install .
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/requirements-tests.txt
+        pip install -r requirements/requirements-core.txt
+        pip install .
     
-    # - name: Run tests
-    #   run: |
-    #     pytest --cov-report term --cov=s2wav --cov-config=.coveragerc 
-    #     codecov --token 298dc7ee-bb9f-4221-b31f-3576cc6cb702
+    - name: Run tests
+      run: |
+        pytest --cov-report term --cov=s2wav --cov-config=.coveragerc 
+        codecov --token 298dc7ee-bb9f-4221-b31f-3576cc6cb702

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ tox -e py38           # for tox
 ```
 
 In the very near future one will be able to install `S2FFT` directly
-from [PyPi]{.title-ref} by `pip install s2fft` but this is not yet
+from [PyPi]{https://pypi.org} by `pip install s2fft` but this is not yet
 supported. Note that to run `JAX` on NVIDIA GPUs you will need to follow
 the [guide](https://github.com/google/jax#installation) outlined by
 Google. 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pixels of equal areas, which has many practical advantages.
 
 The Python dependencies for the `S2FFT` package are listed in the file
 `requirements/requirements-core.txt` and will be automatically installed
-into the active python environment by [pip]{.title-ref} when running
+into the active python environment by [pip](https://pypi.org) when running
 
 ``` bash
 pip install .        
@@ -75,7 +75,7 @@ tox -e py38           # for tox
 ```
 
 In the very near future one will be able to install `S2FFT` directly
-from [PyPi]{https://pypi.org} by `pip install s2fft` but this is not yet
+from [PyPi](https://pypi.org) by `pip install s2fft` but this is not yet
 supported. Note that to run `JAX` on NVIDIA GPUs you will need to follow
 the [guide](https://github.com/google/jax#installation) outlined by
 Google. 

--- a/notebooks/custom_gradients.ipynb
+++ b/notebooks/custom_gradients.ipynb
@@ -1,0 +1,112 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cpu\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Specify CUDA device\n",
+    "import os\n",
+    "os.environ['CUDA_VISIBLE_DEVICES'] = ''\n",
+    "os.environ['JAX_CHECK_TRACER_LEAKS'] = 'True'\n",
+    "\n",
+    "from jax.config import config\n",
+    "config.update(\"jax_enable_x64\", True)\n",
+    "\n",
+    "# Check we're running on GPU\n",
+    "from jax.lib import xla_bridge\n",
+    "print(xla_bridge.get_backend().platform)\n",
+    "\n",
+    "import jax\n",
+    "from jax import jit, grad \n",
+    "import jax.numpy as jnp \n",
+    "from jax.test_util import check_grads\n",
+    "import numpy as np \n",
+    "\n",
+    "import s2fft "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "L = 16\n",
+    "sampling = \"mw\"\n",
+    "np.random.seed(1911851)\n",
+    "f_target = np.random.randn(2*L, 2*L-1)+1j*np.random.randn(2*L, 2*L-1)\n",
+    "flm_target = s2fft.forward_jax(f_target, L, sampling=sampling)\n",
+    "f_target = s2fft.inverse_jax(flm_target, L, sampling=sampling)\n",
+    "precomps = s2fft.generate_precomputes_jax(L, forward=True, sampling=sampling)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(130672510)\n",
+    "f = np.random.randn(2*L, 2*L-1) + 1j*np.random.randn(2*L, 2*L-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def func(f):\n",
+    "    flm = s2fft.forward_jax(f, L, reality=False, precomps=precomps,sampling=sampling)\n",
+    "    return jnp.sum(jnp.abs(flm-flm_target)**2)\n",
+    "grad_func = grad(func)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_grads(func, (f,), order=1, modes=('rev'))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.0 ('s2fft')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "3425e24474cbe920550266ea26b478634978cc419579f9dbcf479231067df6a3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -257,12 +257,12 @@ def inverse_jax(
 
     # Perform latitudinal wigner-d recursions
     @custom_vjp
-    def flm_to_ftm(flm, s, precomps):
+    def flm_to_ftm(flm, spin, precomps):
         return otf.inverse_latitudinal_step_jax(
             flm,
             thetas,
             L,
-            s,
+            spin,
             nside,
             sampling,
             reality,
@@ -271,16 +271,16 @@ def inverse_jax(
             L_lower=L_lower,
         )
 
-    def f_fwd(flm, s, precomps):
-        return flm_to_ftm(flm, s, precomps), ([], s, [])
+    def f_fwd(flm, spin, precomps):
+        return flm_to_ftm(flm, spin, precomps), ([], spin, [])
 
     def f_bwd(res, gtm):
-        s = res[1]
+        spin = res[1]
         glm = otf.forward_latitudinal_step_jax(
             gtm,
             thetas,
             L,
-            s,
+            spin,
             nside,
             sampling,
             reality,
@@ -604,12 +604,12 @@ def forward_jax(
 
     # Perform latitudinal wigner-d recursions
     @custom_vjp
-    def ftm_to_flm(ftm, s, precomps):
+    def ftm_to_flm(ftm, spin, precomps):
         flm = otf.forward_latitudinal_step_jax(
             ftm,
             thetas,
             L,
-            s,
+            spin,
             nside,
             sampling,
             reality,
@@ -619,16 +619,16 @@ def forward_jax(
         )
         return flm
 
-    def f_fwd(ftm, s, precomps):
-        return ftm_to_flm(ftm, s, precomps), ([], s, [])
+    def f_fwd(ftm, spin, precomps):
+        return ftm_to_flm(ftm, spin, precomps), ([], spin, [])
 
     def f_bwd(res, glm):
-        s = res[1]
+        spin = res[1]
         gtm = otf.inverse_latitudinal_step_jax(
             glm,
             thetas,
             L,
-            s,
+            spin,
             nside,
             sampling,
             reality,

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -244,38 +244,53 @@ def inverse_jax(
     thetas = samples.thetas(L, sampling, nside)
     m_offset = 1 if sampling.lower() in ["mwss", "healpix"] else 0
     m_start_ind = L - 1 if reality else 0
-    L0 = L_lower
 
     # Apply harmonic normalisation
-    flm = flm.at[L0:].set(
+    flm = flm.at[L_lower:].set(
         jnp.einsum(
             "lm,l->lm",
-            flm[L0:],
-            jnp.sqrt((2 * jnp.arange(L0, L) + 1) / (4 * jnp.pi)),
+            flm[L_lower:],
+            jnp.sqrt((2 * jnp.arange(L_lower, L) + 1) / (4 * jnp.pi)),
             optimize=True,
         )
     )
 
     # Perform latitudinal wigner-d recursions
-    ftm = otf.inverse_latitudinal_step_jax(
-        flm, thetas, L, spin, nside, sampling, reality, precomps, spmd, L0
-    )
-
-    # Remove south pole singularity
-    if sampling.lower() in ["mw", "mwss"]:
-        ftm = ftm.at[-1].set(0)
-        ftm = ftm.at[-1, L - 1 + spin + m_offset].set(
-            jnp.nansum(
-                (-1) ** abs(jnp.arange(L0, L) - spin) * flm[L0:, L - 1 + spin]
-            )
+    @custom_vjp
+    def func(flm, s, precomps):
+        return otf.inverse_latitudinal_step_jax(
+            flm,
+            thetas,
+            L,
+            s,
+            nside,
+            sampling,
+            reality,
+            precomps=precomps,
+            spmd=spmd,
+            L_lower=L_lower,
         )
 
-    # Remove north pole singularity
-    if sampling.lower() == "mwss":
-        ftm = ftm.at[0].set(0)
-        ftm = ftm.at[0, L - 1 - spin + m_offset].set(
-            jnp.nansum(flm[L0:, L - 1 - spin])
+    def f_fwd(flm, s, precomps):
+        return func(flm, s, precomps), (jnp.zeros_like(flm), s, [])
+
+    def f_bwd(res, gtm):
+        s = res[1]
+        glm = otf.forward_latitudinal_step_jax(
+            gtm,
+            thetas,
+            L,
+            s,
+            nside,
+            sampling,
+            reality,
+            spmd=spmd,
+            L_lower=L_lower,
         )
+        return glm, None, None
+
+    func.defvjp(f_fwd, f_bwd)
+    ftm = func(flm, spin, precomps)
 
     # Correct healpix theta row offsets
     if sampling.lower() == "healpix":
@@ -563,7 +578,6 @@ def forward_jax(
     weights = quadrature_jax.quad_weights_transform(L, sampling, nside)
     m_offset = 1 if sampling in ["mwss", "healpix"] else 0
     m_start_ind = L - 1 if reality else 0
-    L0 = L_lower
 
     # Perform longitundal Fast Fourier Transforms
     if sampling.lower() == "healpix":
@@ -590,69 +604,48 @@ def forward_jax(
 
     # Perform latitudinal wigner-d recursions
     @custom_vjp
-    def func(ftm):
-        return otf.forward_latitudinal_step_jax(
+    def func(ftm, s, precomps):
+        flm = otf.forward_latitudinal_step_jax(
             ftm,
             thetas,
             L,
-            spin,
+            s,
             nside,
             sampling,
             reality,
+            precomps=precomps,
             spmd=spmd,
             L_lower=L_lower,
         )
+        return flm
 
-    def f_fwd(ftm):
-        return func(ftm), (jnp.zeros_like(ftm),)
+    def f_fwd(ftm, s, precomps):
+        return func(ftm, s, precomps), (jnp.zeros_like(ftm), s, [])
 
     def f_bwd(res, glm):
+        s = res[1]
         gtm = otf.inverse_latitudinal_step_jax(
             glm,
             thetas,
             L,
-            spin,
+            s,
             nside,
             sampling,
             reality,
             spmd=spmd,
             L_lower=L_lower,
         )
-        # Remove south pole singularity
-        if sampling.lower() in ["mw", "mwss"]:
-            gtm = gtm.at[-1].set(0)
-            gtm = gtm.at[-1, L - 1 + spin + m_offset].set(
-                jnp.nansum(
-                    (-1) ** abs(jnp.arange(L0, L) - spin)
-                    * glm[L0:, L - 1 + spin]
-                )
-            )
-
-        # Remove north pole singularity
-        if sampling.lower() == "mwss":
-            gtm = gtm.at[0].set(0)
-            gtm = gtm.at[0, L - 1 - spin + m_offset].set(
-                jnp.nansum(glm[L0:, L - 1 - spin])
-            )
-        return (gtm,)
+        return gtm, None, None
 
     func.defvjp(f_fwd, f_bwd)
-    flm = func(ftm)
-
-    # Include both pole singularities explicitly
-    if sampling.lower() == "mwss":
-        flm = flm.at[L0:, L - 1 + spin].add(
-            (-1) ** abs(jnp.arange(L0, L) - spin)
-            * ftm[-1, L - 1 + spin + m_offset]
-        )
-        flm = flm.at[L0:, L - 1 - spin].add(ftm[0, L - 1 - spin + m_offset])
+    flm = func(ftm, spin, precomps)
 
     # Apply harmonic normalisation
-    flm = flm.at[L0:].set(
+    flm = flm.at[L_lower:].set(
         jnp.einsum(
             "lm,l->lm",
-            flm[L0:],
-            jnp.sqrt((2 * jnp.arange(L0, L) + 1) / (4 * jnp.pi)),
+            flm[L_lower:],
+            jnp.sqrt((2 * jnp.arange(L_lower, L) + 1) / (4 * jnp.pi)),
             optimize=True,
         )
     )
@@ -668,7 +661,6 @@ def forward_jax(
         )
 
     # Enforce spin condition explicitly.
-    # TODO: There must be a better way of doing this...
     indices = jnp.repeat(jnp.expand_dims(jnp.arange(L), -1), 2 * L - 1, axis=-1)
     flm = jnp.where(indices < abs(spin), jnp.zeros_like(flm), flm[..., :])
 

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -257,7 +257,7 @@ def inverse_jax(
 
     # Perform latitudinal wigner-d recursions
     @custom_vjp
-    def func(flm, s, precomps):
+    def flm_to_ftm(flm, s, precomps):
         return otf.inverse_latitudinal_step_jax(
             flm,
             thetas,
@@ -272,7 +272,7 @@ def inverse_jax(
         )
 
     def f_fwd(flm, s, precomps):
-        return func(flm, s, precomps), (jnp.zeros_like(flm), s, [])
+        return flm_to_ftm(flm, s, precomps), (jnp.zeros_like(flm), s, [])
 
     def f_bwd(res, gtm):
         s = res[1]
@@ -289,8 +289,8 @@ def inverse_jax(
         )
         return glm, None, None
 
-    func.defvjp(f_fwd, f_bwd)
-    ftm = func(flm, spin, precomps)
+    flm_to_ftm.defvjp(f_fwd, f_bwd)
+    ftm = flm_to_ftm(flm, spin, precomps)
 
     # Correct healpix theta row offsets
     if sampling.lower() == "healpix":
@@ -604,7 +604,7 @@ def forward_jax(
 
     # Perform latitudinal wigner-d recursions
     @custom_vjp
-    def func(ftm, s, precomps):
+    def ftm_to_flm(ftm, s, precomps):
         flm = otf.forward_latitudinal_step_jax(
             ftm,
             thetas,
@@ -620,7 +620,7 @@ def forward_jax(
         return flm
 
     def f_fwd(ftm, s, precomps):
-        return func(ftm, s, precomps), (jnp.zeros_like(ftm), s, [])
+        return ftm_to_flm(ftm, s, precomps), (jnp.zeros_like(ftm), s, [])
 
     def f_bwd(res, glm):
         s = res[1]
@@ -637,8 +637,8 @@ def forward_jax(
         )
         return gtm, None, None
 
-    func.defvjp(f_fwd, f_bwd)
-    flm = func(ftm, spin, precomps)
+    ftm_to_flm.defvjp(f_fwd, f_bwd)
+    flm = ftm_to_flm(ftm, spin, precomps)
 
     # Apply harmonic normalisation
     flm = flm.at[L_lower:].set(

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -272,7 +272,7 @@ def inverse_jax(
         )
 
     def f_fwd(flm, s, precomps):
-        return flm_to_ftm(flm, s, precomps), (jnp.zeros_like(flm), s, [])
+        return flm_to_ftm(flm, s, precomps), ([], s, [])
 
     def f_bwd(res, gtm):
         s = res[1]
@@ -620,7 +620,7 @@ def forward_jax(
         return flm
 
     def f_fwd(ftm, s, precomps):
-        return ftm_to_flm(ftm, s, precomps), (jnp.zeros_like(ftm), s, [])
+        return ftm_to_flm(ftm, s, precomps), ([], s, [])
 
     def f_bwd(res, glm):
         s = res[1]

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -5,7 +5,7 @@ import healpy as hp
 from s2fft.sampling import s2_samples as samples
 
 
-nside_to_test = [32, 64, 128]
+nside_to_test = [16, 32]
 
 
 @pytest.mark.parametrize("L", [15, 16])

--- a/tests/test_spherical_base.py
+++ b/tests/test_spherical_base.py
@@ -6,10 +6,10 @@ import pyssht as ssht
 import healpy as hp
 
 
-L_to_test = [6, 7, 8]
-L_lower_to_test = [0, 1, 2]
-spin_to_test = [-2, -1, 0, 1, 2]
-nside_to_test = [2, 4, 8]
+L_to_test = [6, 7]
+L_lower_to_test = [0, 2]
+spin_to_test = [-2, 0, 1]
+nside_to_test = [4, 5]
 L_to_nside_ratio = [2, 3]
 sampling_to_test = ["mw", "mwss", "dh"]
 method_to_test = ["direct", "sov", "sov_fft", "sov_fft_vectorized"]

--- a/tests/test_spherical_custom_grads.py
+++ b/tests/test_spherical_custom_grads.py
@@ -1,0 +1,225 @@
+from jax import config
+
+config.update("jax_enable_x64", True)
+import pytest
+import numpy as np
+import jax.numpy as jnp
+from jax.test_util import check_grads
+
+from s2fft.sampling import s2_samples as samples
+from s2fft.transforms import spherical
+from s2fft.recursions.price_mcewen import generate_precomputes_jax
+
+L_to_test = [16]
+L_lower_to_test = [0, 2]
+spin_to_test = [-2, 0, 1]
+nside_to_test = [8, 10]
+sampling_to_test = ["mw", "mwss", "dh"]
+reality_to_test = [False, True]
+multiple_gpus = [False]
+
+
+@pytest.mark.parametrize("L", L_to_test)
+@pytest.mark.parametrize("L_lower", L_lower_to_test)
+@pytest.mark.parametrize("spin", spin_to_test)
+@pytest.mark.parametrize("sampling", sampling_to_test)
+@pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("spmd", multiple_gpus)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_inverse_custom_gradients(
+    flm_generator,
+    L: int,
+    L_lower: int,
+    spin: int,
+    sampling: str,
+    reality: bool,
+    spmd: bool,
+):
+    if reality and spin != 0:
+        pytest.skip("Reality only valid for scalar fields (spin=0).")
+
+    flm = flm_generator(L=L, L_lower=L_lower, spin=spin, reality=reality)
+    flm_target = flm_generator(L=L, L_lower=L_lower, spin=spin, reality=reality)
+    f_target = spherical.inverse_jax(
+        flm_target,
+        L,
+        L_lower=L_lower,
+        spin=spin,
+        sampling=sampling,
+        reality=reality,
+    )
+    precomps = generate_precomputes_jax(
+        L, spin, sampling, forward=False, L_lower=L_lower
+    )
+
+    def func(flm):
+        f = spherical.inverse_jax(
+            flm,
+            L,
+            spin=spin,
+            L_lower=L_lower,
+            reality=reality,
+            precomps=precomps,
+            sampling=sampling,
+            spmd=spmd,
+        )
+        return jnp.sum(jnp.abs(f - f_target) ** 2)
+
+    check_grads(func, (flm,), order=1, modes=("rev"))
+
+
+@pytest.mark.parametrize("L", L_to_test)
+@pytest.mark.parametrize("L_lower", L_lower_to_test)
+@pytest.mark.parametrize("spin", spin_to_test)
+@pytest.mark.parametrize("sampling", sampling_to_test)
+@pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("spmd", multiple_gpus)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_forward_custom_gradients(
+    flm_generator,
+    L: int,
+    L_lower: int,
+    spin: int,
+    sampling: str,
+    reality: bool,
+    spmd: bool,
+):
+    if reality and spin != 0:
+        pytest.skip("Reality only valid for scalar fields (spin=0).")
+
+    flm_target = flm_generator(L=L, L_lower=L_lower, spin=spin, reality=reality)
+    flm = flm_generator(L=L, L_lower=L_lower, spin=spin, reality=reality)
+    f = spherical.inverse_jax(
+        flm,
+        L,
+        L_lower=L_lower,
+        spin=spin,
+        sampling=sampling,
+        reality=reality,
+    )
+    precomps = generate_precomputes_jax(
+        L, spin, sampling, forward=True, L_lower=L_lower
+    )
+
+    def func(f):
+        flm = spherical.forward_jax(
+            f,
+            L,
+            spin=spin,
+            L_lower=L_lower,
+            reality=reality,
+            precomps=precomps,
+            sampling=sampling,
+            spmd=spmd,
+        )
+        return jnp.sum(jnp.abs(flm - flm_target) ** 2)
+
+    check_grads(func, (f,), order=1, modes=("rev"))
+
+
+@pytest.mark.parametrize("nside", nside_to_test)
+@pytest.mark.parametrize("L_lower", L_lower_to_test)
+@pytest.mark.parametrize("spin", spin_to_test)
+@pytest.mark.parametrize("sampling", sampling_to_test)
+@pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("spmd", multiple_gpus)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_healpix_inverse_custom_gradients(
+    flm_generator,
+    nside: int,
+    L_lower: int,
+    spin: int,
+    sampling: str,
+    reality: bool,
+    spmd: bool,
+):
+    sampling = "healpix"
+    L = 2 * nside
+
+    if reality and spin != 0:
+        pytest.skip("Reality only valid for scalar fields (spin=0).")
+
+    flm = flm_generator(L=L, L_lower=L_lower, spin=spin, reality=reality)
+    flm_target = flm_generator(L=L, L_lower=L_lower, spin=spin, reality=reality)
+    f_target = spherical.inverse_jax(
+        flm_target,
+        L,
+        L_lower=L_lower,
+        spin=spin,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+    )
+    precomps = generate_precomputes_jax(
+        L, spin, sampling, nside, forward=False, L_lower=L_lower
+    )
+
+    def func(flm):
+        f = spherical.inverse_jax(
+            flm,
+            L,
+            spin=spin,
+            nside=nside,
+            L_lower=L_lower,
+            reality=reality,
+            precomps=precomps,
+            sampling=sampling,
+            spmd=spmd,
+        )
+        return jnp.sum(jnp.abs(f - f_target) ** 2)
+
+    check_grads(func, (flm,), order=1, modes=("rev"))
+
+
+@pytest.mark.parametrize("nside", nside_to_test)
+@pytest.mark.parametrize("L_lower", L_lower_to_test)
+@pytest.mark.parametrize("spin", spin_to_test)
+@pytest.mark.parametrize("sampling", sampling_to_test)
+@pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("spmd", multiple_gpus)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_healpix_forward_custom_gradients(
+    flm_generator,
+    nside: int,
+    L_lower: int,
+    spin: int,
+    sampling: str,
+    reality: bool,
+    spmd: bool,
+):
+    sampling = "healpix"
+    L = 2 * nside
+
+    if reality and spin != 0:
+        pytest.skip("Reality only valid for scalar fields (spin=0).")
+
+    flm_target = flm_generator(L=L, L_lower=L_lower, spin=spin, reality=reality)
+    flm = flm_generator(L=L, L_lower=L_lower, spin=spin, reality=reality)
+    f = spherical.inverse_jax(
+        flm,
+        L,
+        L_lower=L_lower,
+        spin=spin,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+    )
+    precomps = generate_precomputes_jax(
+        L, spin, sampling, nside, forward=True, L_lower=L_lower
+    )
+
+    def func(f):
+        flm = spherical.forward_jax(
+            f,
+            L,
+            spin=spin,
+            nside=nside,
+            L_lower=L_lower,
+            reality=reality,
+            precomps=precomps,
+            sampling=sampling,
+            spmd=spmd,
+        )
+        return jnp.sum(jnp.abs(flm - flm_target) ** 2)
+
+    check_grads(func, (f,), order=1, modes=("rev"))

--- a/tests/test_spherical_custom_grads.py
+++ b/tests/test_spherical_custom_grads.py
@@ -2,21 +2,18 @@ from jax import config
 
 config.update("jax_enable_x64", True)
 import pytest
-import numpy as np
 import jax.numpy as jnp
 from jax.test_util import check_grads
 
-from s2fft.sampling import s2_samples as samples
 from s2fft.transforms import spherical
 from s2fft.recursions.price_mcewen import generate_precomputes_jax
 
 L_to_test = [16]
-L_lower_to_test = [0, 2]
+L_lower_to_test = [2]
 spin_to_test = [-2, 0, 1]
-nside_to_test = [8, 10]
+nside_to_test = [8]
 sampling_to_test = ["mw", "mwss", "dh"]
 reality_to_test = [False, True]
-multiple_gpus = [False]
 
 
 @pytest.mark.parametrize("L", L_to_test)
@@ -24,7 +21,6 @@ multiple_gpus = [False]
 @pytest.mark.parametrize("spin", spin_to_test)
 @pytest.mark.parametrize("sampling", sampling_to_test)
 @pytest.mark.parametrize("reality", reality_to_test)
-@pytest.mark.parametrize("spmd", multiple_gpus)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_inverse_custom_gradients(
     flm_generator,
@@ -33,7 +29,6 @@ def test_inverse_custom_gradients(
     spin: int,
     sampling: str,
     reality: bool,
-    spmd: bool,
 ):
     if reality and spin != 0:
         pytest.skip("Reality only valid for scalar fields (spin=0).")
@@ -61,7 +56,6 @@ def test_inverse_custom_gradients(
             reality=reality,
             precomps=precomps,
             sampling=sampling,
-            spmd=spmd,
         )
         return jnp.sum(jnp.abs(f - f_target) ** 2)
 
@@ -73,7 +67,6 @@ def test_inverse_custom_gradients(
 @pytest.mark.parametrize("spin", spin_to_test)
 @pytest.mark.parametrize("sampling", sampling_to_test)
 @pytest.mark.parametrize("reality", reality_to_test)
-@pytest.mark.parametrize("spmd", multiple_gpus)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_forward_custom_gradients(
     flm_generator,
@@ -82,7 +75,6 @@ def test_forward_custom_gradients(
     spin: int,
     sampling: str,
     reality: bool,
-    spmd: bool,
 ):
     if reality and spin != 0:
         pytest.skip("Reality only valid for scalar fields (spin=0).")
@@ -110,7 +102,6 @@ def test_forward_custom_gradients(
             reality=reality,
             precomps=precomps,
             sampling=sampling,
-            spmd=spmd,
         )
         return jnp.sum(jnp.abs(flm - flm_target) ** 2)
 
@@ -122,7 +113,6 @@ def test_forward_custom_gradients(
 @pytest.mark.parametrize("spin", spin_to_test)
 @pytest.mark.parametrize("sampling", sampling_to_test)
 @pytest.mark.parametrize("reality", reality_to_test)
-@pytest.mark.parametrize("spmd", multiple_gpus)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_healpix_inverse_custom_gradients(
     flm_generator,
@@ -131,7 +121,6 @@ def test_healpix_inverse_custom_gradients(
     spin: int,
     sampling: str,
     reality: bool,
-    spmd: bool,
 ):
     sampling = "healpix"
     L = 2 * nside
@@ -164,7 +153,6 @@ def test_healpix_inverse_custom_gradients(
             reality=reality,
             precomps=precomps,
             sampling=sampling,
-            spmd=spmd,
         )
         return jnp.sum(jnp.abs(f - f_target) ** 2)
 
@@ -176,7 +164,6 @@ def test_healpix_inverse_custom_gradients(
 @pytest.mark.parametrize("spin", spin_to_test)
 @pytest.mark.parametrize("sampling", sampling_to_test)
 @pytest.mark.parametrize("reality", reality_to_test)
-@pytest.mark.parametrize("spmd", multiple_gpus)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_healpix_forward_custom_gradients(
     flm_generator,
@@ -185,7 +172,6 @@ def test_healpix_forward_custom_gradients(
     spin: int,
     sampling: str,
     reality: bool,
-    spmd: bool,
 ):
     sampling = "healpix"
     L = 2 * nside
@@ -218,7 +204,6 @@ def test_healpix_forward_custom_gradients(
             reality=reality,
             precomps=precomps,
             sampling=sampling,
-            spmd=spmd,
         )
         return jnp.sum(jnp.abs(flm - flm_target) ** 2)
 

--- a/tests/test_spherical_precompute.py
+++ b/tests/test_spherical_precompute.py
@@ -4,9 +4,9 @@ from s2fft.precompute_transforms.spherical import inverse, forward
 from s2fft.precompute_transforms.construct import spin_spherical_kernel
 from s2fft.base_transforms import spherical as base
 
-L_to_test = [6, 7, 8]
-spin_to_test = [-2, -1, 0, 1, 2]
-nside_to_test = [2, 4, 8]
+L_to_test = [6, 7]
+spin_to_test = [-2, 0, 1]
+nside_to_test = [4, 5]
 L_to_nside_ratio = [2, 3]
 sampling_to_test = ["mw", "mwss", "dh"]
 reality_to_test = [True, False]

--- a/tests/test_spherical_transform.py
+++ b/tests/test_spherical_transform.py
@@ -10,10 +10,10 @@ from s2fft.sampling import s2_samples as samples
 from s2fft.transforms import spherical
 from s2fft.recursions.price_mcewen import generate_precomputes
 
-L_to_test = [6, 7, 8]
-L_lower_to_test = [0, 1, 2]
-spin_to_test = [-2, -1, 0, 1, 2]
-nside_to_test = [2, 4, 8]
+L_to_test = [6, 7]
+L_lower_to_test = [0, 2]
+spin_to_test = [-2, 0, 1]
+nside_to_test = [4, 5]
 sampling_to_test = ["mw", "mwss", "dh"]
 method_to_test = ["numpy", "jax"]
 reality_to_test = [False, True]

--- a/tests/test_wigner_base.py
+++ b/tests/test_wigner_base.py
@@ -5,9 +5,9 @@ from s2fft.sampling import so3_samples as samples
 from s2fft.base_transforms import wigner
 
 
-L_to_test = [8, 16]
-N_to_test = [2, 4, 6]
-L_lower_to_test = [0, 2, 4]
+L_to_test = [6, 7]
+N_to_test = [2, 3]
+L_lower_to_test = [0, 2]
 sampling_schemes_so3 = ["mw", "mwss"]
 sampling_schemes = ["mw", "mwss", "dh"]
 reality_to_test = [False, True]

--- a/tests/test_wigner_custom_grads.py
+++ b/tests/test_wigner_custom_grads.py
@@ -8,12 +8,11 @@ from jax.test_util import check_grads
 from s2fft.transforms import wigner
 from s2fft.recursions.price_mcewen import generate_precomputes_wigner_jax
 
-L_to_test = [16]
-N_to_test = [2]
-L_lower_to_test = [0, 2]
+L_to_test = [6]
+N_to_test = [3]
+L_lower_to_test = [1]
 sampling_to_test = ["mw", "mwss", "dh"]
-reality_to_test = [False]
-multiple_gpus = [False]
+reality_to_test = [False, True]
 
 
 @pytest.mark.parametrize("L", L_to_test)
@@ -21,7 +20,6 @@ multiple_gpus = [False]
 @pytest.mark.parametrize("L_lower", L_lower_to_test)
 @pytest.mark.parametrize("sampling", sampling_to_test)
 @pytest.mark.parametrize("reality", reality_to_test)
-@pytest.mark.parametrize("spmd", multiple_gpus)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_inverse_wigner_custom_gradients(
     flmn_generator,
@@ -30,7 +28,6 @@ def test_inverse_wigner_custom_gradients(
     L_lower: int,
     sampling: str,
     reality: bool,
-    spmd: bool,
 ):
     precomps = generate_precomputes_wigner_jax(
         L, N, sampling, None, False, reality, L_lower
@@ -39,12 +36,12 @@ def test_inverse_wigner_custom_gradients(
     flmn = flmn_generator(L=L, N=N, L_lower=L_lower, reality=reality)
     flmn_target = flmn_generator(L=L, N=N, L_lower=L_lower, reality=reality)
     f_target = wigner.inverse_jax(
-        flmn_target, L, N, None, sampling, reality, precomps, spmd, L_lower
+        flmn_target, L, N, None, sampling, reality, precomps, False, L_lower
     )
 
     def func(flmn):
         f = wigner.inverse_jax(
-            flmn, L, N, None, sampling, reality, precomps, spmd, L_lower
+            flmn, L, N, None, sampling, reality, precomps, False, L_lower
         )
         return jnp.sum(jnp.abs(f - f_target) ** 2)
 
@@ -56,7 +53,6 @@ def test_inverse_wigner_custom_gradients(
 @pytest.mark.parametrize("L_lower", L_lower_to_test)
 @pytest.mark.parametrize("sampling", sampling_to_test)
 @pytest.mark.parametrize("reality", reality_to_test)
-@pytest.mark.parametrize("spmd", multiple_gpus)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_forward_wigner_custom_gradients(
     flmn_generator,
@@ -65,7 +61,6 @@ def test_forward_wigner_custom_gradients(
     L_lower: int,
     sampling: str,
     reality: bool,
-    spmd: bool,
 ):
     precomps = generate_precomputes_wigner_jax(
         L, N, sampling, None, True, reality, L_lower
@@ -74,12 +69,12 @@ def test_forward_wigner_custom_gradients(
     flmn_target = flmn_generator(L=L, N=N, L_lower=L_lower, reality=reality)
     flmn = flmn_generator(L=L, N=N, L_lower=L_lower, reality=reality)
     f = wigner.inverse_jax(
-        flmn, L, N, None, sampling, reality, None, spmd, L_lower
+        flmn, L, N, None, sampling, reality, None, False, L_lower
     )
 
     def func(f):
         flmn = wigner.forward_jax(
-            f, L, N, None, sampling, reality, precomps, spmd, L_lower
+            f, L, N, None, sampling, reality, precomps, False, L_lower
         )
         return jnp.sum(jnp.abs(flmn - flmn_target) ** 2)
 

--- a/tests/test_wigner_custom_grads.py
+++ b/tests/test_wigner_custom_grads.py
@@ -1,0 +1,86 @@
+from jax import config
+
+config.update("jax_enable_x64", True)
+import pytest
+import jax.numpy as jnp
+from jax.test_util import check_grads
+
+from s2fft.transforms import wigner
+from s2fft.recursions.price_mcewen import generate_precomputes_wigner_jax
+
+L_to_test = [16]
+N_to_test = [2]
+L_lower_to_test = [0, 2]
+sampling_to_test = ["mw", "mwss", "dh"]
+reality_to_test = [False]
+multiple_gpus = [False]
+
+
+@pytest.mark.parametrize("L", L_to_test)
+@pytest.mark.parametrize("N", N_to_test)
+@pytest.mark.parametrize("L_lower", L_lower_to_test)
+@pytest.mark.parametrize("sampling", sampling_to_test)
+@pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("spmd", multiple_gpus)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_inverse_wigner_custom_gradients(
+    flmn_generator,
+    L: int,
+    N: int,
+    L_lower: int,
+    sampling: str,
+    reality: bool,
+    spmd: bool,
+):
+    precomps = generate_precomputes_wigner_jax(
+        L, N, sampling, None, False, reality, L_lower
+    )
+
+    flmn = flmn_generator(L=L, N=N, L_lower=L_lower, reality=reality)
+    flmn_target = flmn_generator(L=L, N=N, L_lower=L_lower, reality=reality)
+    f_target = wigner.inverse_jax(
+        flmn_target, L, N, None, sampling, reality, precomps, spmd, L_lower
+    )
+
+    def func(flmn):
+        f = wigner.inverse_jax(
+            flmn, L, N, None, sampling, reality, precomps, spmd, L_lower
+        )
+        return jnp.sum(jnp.abs(f - f_target) ** 2)
+
+    check_grads(func, (flmn,), order=1, modes=("rev"))
+
+
+@pytest.mark.parametrize("L", L_to_test)
+@pytest.mark.parametrize("N", N_to_test)
+@pytest.mark.parametrize("L_lower", L_lower_to_test)
+@pytest.mark.parametrize("sampling", sampling_to_test)
+@pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("spmd", multiple_gpus)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_forward_wigner_custom_gradients(
+    flmn_generator,
+    L: int,
+    N: int,
+    L_lower: int,
+    sampling: str,
+    reality: bool,
+    spmd: bool,
+):
+    precomps = generate_precomputes_wigner_jax(
+        L, N, sampling, None, True, reality, L_lower
+    )
+
+    flmn_target = flmn_generator(L=L, N=N, L_lower=L_lower, reality=reality)
+    flmn = flmn_generator(L=L, N=N, L_lower=L_lower, reality=reality)
+    f = wigner.inverse_jax(
+        flmn, L, N, None, sampling, reality, None, spmd, L_lower
+    )
+
+    def func(f):
+        flmn = wigner.forward_jax(
+            f, L, N, None, sampling, reality, precomps, spmd, L_lower
+        )
+        return jnp.sum(jnp.abs(flmn - flmn_target) ** 2)
+
+    check_grads(func, (f,), order=1, modes=("rev"))

--- a/tests/test_wigner_precompute.py
+++ b/tests/test_wigner_precompute.py
@@ -6,9 +6,9 @@ from s2fft.precompute_transforms.construct import wigner_kernel
 from s2fft.base_transforms import wigner as base
 
 L_to_test = [8, 10]
-N_to_test = [2, 4]
+N_to_test = [2, 3]
 nside_to_test = [4, 6]
-L_to_nside_ratio = [2, 3]
+L_to_nside_ratio = [2]
 reality_to_test = [False, True]
 sampling_schemes = ["mw", "mwss", "dh"]
 methods_to_test = ["numpy", "jax"]

--- a/tests/test_wigner_recursions.py
+++ b/tests/test_wigner_recursions.py
@@ -8,8 +8,8 @@ from s2fft import recursions
 from s2fft.sampling import s2_samples as samples
 import pyssht as ssht
 
-L_to_test = [8, 16]
-spin_to_test = np.arange(-2, 2)
+L_to_test = [6, 7]
+spin_to_test = [-2, 0, 1]
 sampling_schemes = ["mw", "mwss", "dh", "healpix"]
 
 

--- a/tests/test_wigner_samples.py
+++ b/tests/test_wigner_samples.py
@@ -4,7 +4,7 @@ import numpy as np
 from s2fft.sampling import so3_samples as samples
 
 L_to_test = [8, 16]
-N_to_test = [2, 4, 6]
+N_to_test = [2, 4]
 sampling_schemes = ["mw", "mwss"]
 
 

--- a/tests/test_wigner_transform.py
+++ b/tests/test_wigner_transform.py
@@ -11,9 +11,9 @@ from s2fft.recursions.price_mcewen import (
     generate_precomputes_wigner_jax,
 )
 
-L_to_test = [6, 8]
-N_to_test = [2, 4]
-L_lower_to_test = [0, 2, 4]
+L_to_test = [6, 7]
+N_to_test = [2, 3]
+L_lower_to_test = [0, 2]
 sampling_to_test = ["mw", "mwss", "dh"]
 method_to_test = ["numpy", "jax"]
 reality_to_test = [False, True]


### PR DESCRIPTION
This PR switches out fully automatic differentiation to a `custom_vjp` implementation. There are two options regarding this, as the spherical harmonic transform is holomorphic, the right multiplication of gradients in the [Vector-Jacobian Product (VJP)](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html) is invariant under transposition, leading to:

- VJP of forward transform = conjugate of the inverse spherical harmonic transform of the conjugate of the cotangents.
- JVP of forward transform = forward transform of tangents.

And similarly for the inverse spherical harmonic transforms. The issue with this, is that we have a resampling step for "mw" and "mwss" which slightly modifies this relationship, and would require some, potentially very ugly, code. Instead, we can strike a middle ground by explicitly defining the VJP for the latitudinal step alone, and leave the remaining  propagation of the cotangent to vanilla AD. This avoids the memory overhead associated with applying grad of a scan with large carry terms.

**tl;dr: with this update the gradients should be approximately the same cost as the transforms, both in terms of memory and wall-time (they can also be distributed over multiple GPUs on a single node with [SPMD](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD)).**

### Core Content
- [x] Add custom gradient for forward spin-spherical harmonic transform
- [x] Add custom gradient for inverse spin-spherical harmonic transform
- [x] Filter precomputed matrices into custom gradients
- [x] Ensure gradient functionality extends to Wigner transforms
- [x] Add unit tests for added functionality (all to machine precision, and $\mathcal{O}(L^2)$ peak memory on GPU device).

### Additional Content
- [x] Reactivated CI as Conan SSHT wheel issues have been resolved
- [x] Minor tidying of various, now redundant, variables.