### PR TITLE
Use codecov-action in place of manual upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,5 +32,9 @@ jobs:
     
     - name: Run tests
       run: |
-        pytest --cov-report term --cov=s2fft --cov-config=.coveragerc 
-        codecov --token 298dc7ee-bb9f-4221-b31f-3576cc6cb702
+        pytest --cov-report=xml --cov=s2fft --cov-config=.coveragerc
+  
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ plotting = [
 tests = [
     "pytest",
     "pytest-cov",
-    "codecov",
     "so3",
 ]
 


### PR DESCRIPTION
Would resolve #211 

Will require a repository secret `CODECOV_TOKEN ` to be added with a [Codecov repository upload token](https://docs.codecov.com/docs/frequently-asked-questions#where-is-the-repository-upload-token-found) set to work.