### PR TITLE
Add configuration for automatic release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - infrastructure
+    authors:
+      - allcontributors
+  categories:
+    - title: ✨ New features
+      labels:
+        - enhancement
+    - title: 📖 Documentation improvements
+      labels:
+        - documentation
+    - title: 🐛 Bug fixes
+      labels:
+        - bug
+    - title: 📦 Dependency updates
+      labels:
+        - dependencies
+    - title: 🛠 Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Resolves #218 

Adds a `.github/release.yml` file specifying (pull request) label to category mapping for automatically generated release notes. I have specified to ignore pull-requests authored by `allcontributors` bot and any tagged with `infrastructure` label from release notes (the latter with the assumption these changes are not of direct relevance to users and for example won't affect semantic versioning).