### PR TITLE
Update citation details in docs and add CITATION.cff file

### DIFF
--- a/.pip_readme.rst
+++ b/.pip_readme.rst
@@ -52,8 +52,11 @@ referenced. A BibTeX entry for this reference may look like:
         author      = "Matthew A. Price and Jason D. McEwen",
         title       = "Differentiable and accelerated spherical harmonic and Wigner transforms",
         journal     = "Journal of Computational Physics",
-        year        = "2023",
-        eprint      = "arXiv:2311.14670"        
+        year        = "2024",
+        volume      = "510",
+        pages       = "113109",
+        eprint      = "arXiv:2311.14670",
+        doi         = "10.1016/j.jcp.2024.113109"
     }
 
 You might also like to consider citing our related papers on which this

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,10 +8,12 @@ authors:
   - given-names: Matthew A.
     family-names: Price
     affiliation: University College London
+    website: 'https://cosmomatt.github.io/'
   - given-names: Jason
     orcid: 'https://orcid.org/0000-0002-5852-8890'
     family-names: McEwen
     affiliation: University College London
+    website: 'http://www.jasonmcewen.org/'
 repository-code: 'https://github.com/astro-informatics/s2fft'
 url: 'https://astro-informatics.github.io/s2fft'
 license: MIT
@@ -21,9 +23,11 @@ preferred-citation:
   - family-names: Matthew A.
     given-names: Price
     affiliation: University College London
+    website: 'https://cosmomatt.github.io/''
   - family-names: Jason
     given-names: McEwen
     orcid: 'https://orcid.org/0000-0002-5852-8890'
+    website: 'http://www.jasonmcewen.org/''
   doi: 10.1016/j.jcp.2024.113109
   journal: Journal of Computational Physics
   month: 8

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+title: >-
+  s2fft: Differentiable and accelerated spherical transforms with JAX
+message: >-
+  If you use this software, please cite it using the metadata from this file.
+type: software
+authors:
+  - given-names: Matthew A.
+    family-names: Price
+    affiliation: University College London
+  - given-names: Jason
+    orcid: 'https://orcid.org/0000-0002-5852-8890'
+    family-names: McEwen
+    affiliation: University College London
+repository-code: 'https://github.com/astro-informatics/s2fft'
+url: 'https://astro-informatics.github.io/s2fft'
+license: MIT
+preferred-citation:
+  type: article
+  authors:
+  - family-names: Matthew A.
+    given-names: Price
+    affiliation: University College London
+  - family-names: Jason
+    given-names: McEwen
+    orcid: 'https://orcid.org/0000-0002-5852-8890'
+  doi: 10.1016/j.jcp.2024.113109
+  journal: Journal of Computational Physics
+  month: 8
+  start: 113109
+  title: Differentiable and accelerated spherical harmonic and Wigner transforms
+  issue: 1
+  volume: 510
+  year: 2024

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 # Differentiable and accelerated spherical transforms
 
 `S2FFT` is a Python package for computing Fourier transforms on the sphere
-and rotation group [(Price & McEwen 2023)](https://arxiv.org/abs/2311.14670) using 
+and rotation group [(Price & McEwen 2024)](https://arxiv.org/abs/2311.14670) using 
 JAX or PyTorch. It leverages autodiff to provide differentiable transforms, which are 
 also deployable on hardware accelerators (e.g. GPUs and TPUs).
 
@@ -44,7 +44,7 @@ parallelised and distributed, and so map very well onto the architecture
 of hardware accelerators (i.e. GPUs and TPUs). In particular, these
 algorithms are based on new Wigner-d recursions that are stable to high
 angular resolution $L$. The diagram below illustrates the recursions
-(for further details see Price & McEwen, in prep.).
+(for further details see [Price & McEwen 2024]((https://arxiv.org/abs/2311.14670))).
 
 ![image](./docs/assets/figures/Wigner_recursion_legend_darkmode.png)
 With this recursion to hand, the spherical harmonic coefficients of an 
@@ -57,7 +57,7 @@ Alternatively, the real polar-d functions may calculated recursively,
 computing only a portion of the projection at a time, hence incurring 
 negligible memory overhead at the cost of slightly slower execution. The 
 diagram below illustrates the separable spherical harmonic transform 
-(for further details see Price & McEwen, in prep.).
+(for further details see [Price & McEwen 2024]((https://arxiv.org/abs/2311.14670))).
 
 ![image](./docs/assets/figures/sax_schematic_legend_darkmode.png)
 
@@ -185,9 +185,9 @@ in `S2FFT` against the C implementations in the
 
 A brief summary is shown in the table below for the recursion (left) and
 precompute (right) algorithms, with `S2FFT` running on GPUs (for further
-details see Price & McEwen, in prep.). Note that our compute time is
-agnostic to spin number (which is not the case for many other methods
-that scale linearly with spin).
+details see [Price & McEwen 2024]((https://arxiv.org/abs/2311.14670))). 
+Note that our compute time is agnostic to spin number (which is not the 
+case for many other methods that scale linearly with spin).
 
 | L    | Wall-Time | Speed-up | Error    | Wall-Time | Speed-up | Error    | Memory  |
 |------|-----------|----------|----------|-----------|----------|----------|---------|

--- a/README.md
+++ b/README.md
@@ -247,9 +247,12 @@ referenced. A BibTeX entry for this reference may look like:
 @article{price:s2fft, 
    author      = "Matthew A. Price and Jason D. McEwen",
    title       = "Differentiable and accelerated spherical harmonic and Wigner transforms",
-   journal     = "Journal of Computational Physics, submitted",
-   year        = "2023",
-   eprint      = "arXiv:2311.14670"        
+   journal     = "Journal of Computational Physics",
+   year        = "2024",
+   volume      = "510",
+   pages       = "113109",
+   eprint      = "arXiv:2311.14670",
+   doi         = "10.1016/j.jcp.2024.113109"
 }
 ```
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,9 +109,12 @@ article is referenced. A BibTeX entry for this reference may look like:
     @article{price:s2fft, 
         author      = "Matthew A. Price and Jason D. McEwen",
         title       = "Differentiable and accelerated spherical harmonic and Wigner transforms",
-        journal     = "Journal of Computational Physics, submitted",
-        year        = "2023",
-        eprint      = "arXiv:2311.14670"        
+        journal     = "Journal of Computational Physics",
+        year        = "2024",
+        volume      = "510",
+        pages       = "113109",
+        eprint      = "arXiv:2311.14670",
+        doi         = "10.1016/j.jcp.2024.113109"
     }
 
 You might also like to consider citing our related papers on which this code builds:


### PR DESCRIPTION
Resolves #225 and resolves #217 

Updates the citation BibTeX details in various places in documentation to reflected published and accepted version of JCP article and also adds a `CITATION.cff` file with this citation data.

The default behaviour of `CITATION.cff` is to list the citation metadata for the software itself however there is a `preferred-citation` field for adding details of another artefact that should be cited in preference first. I've added JCP article details to this field and some basic metadata for software to main fields. For now I've just listed @CosmoMatt and @jasonmcewen as authors on the software. An alternative would be to list all contributors for example.