### PR TITLE
add stable forward/inverse memory efficient Wigner transforms

### DIFF
--- a/docs/api/precompute_transforms/fourier_wigner.rst
+++ b/docs/api/precompute_transforms/fourier_wigner.rst
@@ -1,0 +1,7 @@
+:html_theme.sidebar_secondary.remove:
+
+**************************
+Fourier-Wigner Transform
+**************************
+.. automodule:: s2fft.precompute_transforms.fourier_wigner
+   :members: 

--- a/docs/api/precompute_transforms/index.rst
+++ b/docs/api/precompute_transforms/index.rst
@@ -50,6 +50,21 @@ Precompute Functions
    * - :func:`~s2fft.precompute_transforms.wigner.forward_transform_torch`
      - Forward Wigner transform (Torch)
 
+.. list-table:: Fourier-Wigner transforms.
+   :widths: 25 25
+   :header-rows: 1
+
+   * - Function Name
+     - Description
+   * - :func:`~s2fft.precompute_transforms.fourier_wigner.inverse_transform`
+     - Inverse Wigner transform with Fourier method (NumPy)
+   * - :func:`~s2fft.precompute_transforms.fourier_wigner.inverse_transform_jax`
+     - Inverse Wigner transform with Fourier method (JAX)
+   * - :func:`~s2fft.precompute_transforms.fourier_wigner.forward_transform`
+     - Forward Wigner transform with Fourier method (NumPy)
+   * - :func:`~s2fft.precompute_transforms.fourier_wigner.forward_transform_jax`
+     - Forward Wigner transform with Fourier method (JAX)
+
 .. list-table:: Constructing Kernels for precompute transforms.
    :widths: 25 25
    :header-rows: 1
@@ -64,6 +79,10 @@ Precompute Functions
      - Builds a kernel including quadrature weights and Wigner-D coefficients for spherical harmonic transform (JAX).
    * - :func:`~s2fft.precompute_transforms.construct.wigner_kernel_jax`
      - Builds a kernel including quadrature weights and Wigner-D coefficients for Wigner transform (JAX).
+   * - :func:`~s2fft.precompute_transforms.construct.fourier_wigner_kernel`
+     - Builds a kernel including quadrature weights and Fourier coefficienfs of Wigner d-functions
+   * - :func:`~s2fft.precompute_transforms.construct.fourier_wigner_kernel_jax`
+     - Builds a kernel including quadrature weights and Fourier coefficienfs of Wigner d-functions (JAX).
    * - :func:`~s2fft.precompute_transforms.construct.healpix_phase_shifts`
      - Builds a vector of corresponding phase shifts for each HEALPix latitudinal ring.
 
@@ -76,4 +95,5 @@ Precompute Functions
    alt_construct
    spin_spherical 
    wigner
+   fourier_wigner
 

--- a/s2fft/precompute_transforms/__init__.py
+++ b/s2fft/precompute_transforms/__init__.py
@@ -1,1 +1,1 @@
-from . import construct, spherical, wigner
+from . import construct, fourier_wigner, spherical, wigner

--- a/s2fft/precompute_transforms/fourier_wigner.py
+++ b/s2fft/precompute_transforms/fourier_wigner.py
@@ -7,7 +7,7 @@ from jax import jit
 
 def inverse_transform(
     flmn: np.ndarray,
-    delta: np.ndarray,
+    DW: np.ndarray,
     L: int,
     N: int,
     reality: bool = False,
@@ -18,7 +18,7 @@ def inverse_transform(
 
     Args:
         flmn (np.ndarray): Wigner coefficients.
-        delta (Tuple[np.ndarray, np.ndarray]): Fourier coefficients of the reduced
+        DW (Tuple[np.ndarray, np.ndarray], optional): Fourier coefficients of the reduced
             Wigner d-functions and the corresponding upsampled quadrature weights.
         L (int): Harmonic band-limit.
         N (int): Azimuthal band-limit.
@@ -32,6 +32,14 @@ def inverse_transform(
         np.ndarray: Pixel-space function sampled on the rotation group.
 
     """
+    if sampling.lower() not in ["mw", "mwss"]:
+        raise ValueError(
+            f"Fourier-Wigner algorithm does not support {sampling} sampling."
+        )
+
+    # EXTRACT VARIOUS PRECOMPUTES
+    Delta, _ = DW
+
     # INDEX VALUES
     n_start_ind = N - 1 if reality else 0
     n_dim = N if reality else 2 * N - 1
@@ -44,13 +52,13 @@ def inverse_transform(
     m = np.arange(-L + 1 - m_offset, L)
     n = np.arange(n_start_ind - N + 1, N)
 
-    # Calculate fmna = i^(n-m)\sum_L delta^l_am delta^l_an f^l_mn(2l+1)/(8pi^2)
+    # Calculate fmna = i^(n-m)\sum_L Delta^l_am Delta^l_an f^l_mn(2l+1)/(8pi^2)
     x = np.zeros((xnlm_size, xnlm_size, n_dim), dtype=flmn.dtype)
     x[m_offset:, m_offset:] = np.einsum(
         "nlm,lam,lan,l->amn",
         flmn[n_start_ind:],
-        delta[0],
-        delta[0][:, :, L - 1 + n],
+        Delta,
+        Delta[:, :, L - 1 + n],
         (2 * np.arange(L) + 1) / (8 * np.pi**2),
     )
 
@@ -72,7 +80,7 @@ def inverse_transform(
 @partial(jit, static_argnums=(2, 3, 4, 5))
 def inverse_transform_jax(
     flmn: jnp.ndarray,
-    delta: jnp.ndarray,
+    DW: jnp.ndarray,
     L: int,
     N: int,
     reality: bool = False,
@@ -83,7 +91,7 @@ def inverse_transform_jax(
 
     Args:
         flmn (jnp.ndarray): Wigner coefficients.
-        delta (Tuple[jnp.ndarray, jnp.ndarray]): Fourier coefficients of the reduced
+        DW (Tuple[np.ndarray, np.ndarray]): Fourier coefficients of the reduced
             Wigner d-functions and the corresponding upsampled quadrature weights.
         L (int): Harmonic band-limit.
         N (int): Azimuthal band-limit.
@@ -97,6 +105,14 @@ def inverse_transform_jax(
         jnp.ndarray: Pixel-space function sampled on the rotation group.
 
     """
+    if sampling.lower() not in ["mw", "mwss"]:
+        raise ValueError(
+            f"Fourier-Wigner algorithm does not support {sampling} sampling."
+        )
+
+    # EXTRACT VARIOUS PRECOMPUTES
+    Delta, _ = DW
+
     # INDEX VALUES
     n_start_ind = N - 1 if reality else 0
     n_dim = N if reality else 2 * N - 1
@@ -109,17 +125,15 @@ def inverse_transform_jax(
     m = jnp.arange(-L + 1 - m_offset, L)
     n = jnp.arange(n_start_ind - N + 1, N)
 
-    # Calculate fmna = i^(n-m)\sum_L delta^l_am delta^l_an f^l_mn(2l+1)/(8pi^2)
-    x = jnp.zeros((xnlm_size, xnlm_size, n_dim), dtype=flmn.dtype)
+    # Calculate fmna = i^(n-m)\sum_L Delta^l_am Delta^l_an f^l_mn(2l+1)/(8pi^2)
+    x = jnp.zeros((xnlm_size, xnlm_size, n_dim), dtype=jnp.complex128)
+    flmn = jnp.einsum("nlm,l->nlm", flmn, (2 * jnp.arange(L) + 1) / (8 * jnp.pi**2))
     x = x.at[m_offset:, m_offset:].set(
         jnp.einsum(
-            "nlm,lam,lan,l->amn",
-            flmn[n_start_ind:],
-            delta[0],
-            delta[0][:, :, L - 1 + n],
-            (2 * jnp.arange(L) + 1) / (8 * jnp.pi**2),
+            "nlm,lam,lan->amn", flmn[n_start_ind:], Delta, Delta[:, :, L - 1 + n]
         )
     )
+
     # APPLY SIGN FUNCTION AND PHASE SHIFT
     x = jnp.einsum("amn,m,n,a->nam", x, 1j ** (-m), 1j ** (n), jnp.exp(1j * m * theta0))
 
@@ -136,14 +150,19 @@ def inverse_transform_jax(
 
 
 def forward_transform(
-    f: np.ndarray, delta: np.ndarray, L: int, N: int, reality: bool, sampling: str
+    f: np.ndarray,
+    DW: np.ndarray,
+    L: int,
+    N: int,
+    reality: bool = False,
+    sampling: str = "mw",
 ) -> np.ndarray:
     """
     Computes the forward Wigner transform using the Fourier decomposition algorithm.
 
     Args:
         f (np.ndarray): Function sampled on the rotation group.
-        delta (Tuple[np.ndarray, np.ndarray]): Fourier coefficients of the reduced
+        DW (Tuple[np.ndarray, np.ndarray], optional): Fourier coefficients of the reduced
             Wigner d-functions and the corresponding upsampled quadrature weights.
         L (int): Harmonic band-limit.
         N (int): Azimuthal band-limit.
@@ -157,6 +176,14 @@ def forward_transform(
         np.ndarray: Wigner coefficients of function f.
 
     """
+    if sampling.lower() not in ["mw", "mwss"]:
+        raise ValueError(
+            f"Fourier-Wigner algorithm does not support {sampling} sampling."
+        )
+
+    # EXTRACT VARIOUS PRECOMPUTES
+    Delta, Quads = DW
+
     # INDEX VALUES
     n_start_ind = N - 1 if reality else 0
     m_offset = 1 if sampling.lower() == "mwss" else 0
@@ -193,14 +220,17 @@ def forward_transform(
     x = np.fft.ifft(x, axis=1, norm="forward")
 
     # PERFORM QUADRATURE CONVOLUTION AS FFT REWEIGHTING IN REAL SPACE
-    x = np.einsum("nbm,b->nbm", x, delta[1])
+    # NB: Our convention here is conjugate to that of SSHT, in which
+    # the weights are conjugate but applied flipped and therefore are
+    # equivalent. To avoid flipping here he simply conjugate the weights.
+    x = np.einsum("nbm,b->nbm", x, Quads)
 
     # COMPUTE GMM BY FFT
     x = np.fft.fft(x, axis=1, norm="forward")
     x = np.fft.fftshift(x, axes=1)[:, L - 1 : 3 * L - 2]
 
-    # Calculate flmn = i^(n-m)\sum_t delta^l_tm delta^l_tn G_mnt
-    x = np.einsum("nam,lam,lan->nlm", x, delta[0], delta[0][:, :, L - 1 + n])
+    # Calculate flmn = i^(n-m)\sum_t Delta^l_tm Delta^l_tn G_mnt
+    x = np.einsum("nam,lam,lan->nlm", x, Delta, Delta[:, :, L - 1 + n])
     x = np.einsum("nbm,m,n->nbm", x, 1j ** (m), 1j ** (-n))
 
     # SYMMETRY REFLECT FOR N < 0
@@ -218,14 +248,19 @@ def forward_transform(
 
 @partial(jit, static_argnums=(2, 3, 4, 5))
 def forward_transform_jax(
-    f: jnp.ndarray, delta: jnp.ndarray, L: int, N: int, reality: bool, sampling: str
+    f: jnp.ndarray,
+    DW: jnp.ndarray,
+    L: int,
+    N: int,
+    reality: bool = False,
+    sampling: str = "mw",
 ) -> jnp.ndarray:
     """
     Computes the forward Wigner transform using the Fourier decomposition algorithm (JAX).
 
     Args:
         f (jnp.ndarray): Function sampled on the rotation group.
-        delta (Tuple[jnp.ndarray, jnp.ndarray]): Fourier coefficients of the reduced
+        DW (Tuple[jnp.ndarray, jnp.ndarray]): Fourier coefficients of the reduced
             Wigner d-functions and the corresponding upsampled quadrature weights.
         L (int): Harmonic band-limit.
         N (int): Azimuthal band-limit.
@@ -239,6 +274,14 @@ def forward_transform_jax(
         jnp.ndarray: Wigner coefficients of function f.
 
     """
+    if sampling.lower() not in ["mw", "mwss"]:
+        raise ValueError(
+            f"Fourier-Wigner algorithm does not support {sampling} sampling."
+        )
+
+    # EXTRACT VARIOUS PRECOMPUTES
+    Delta, Quads = DW
+
     # INDEX VALUES
     n_start_ind = N - 1 if reality else 0
     m_offset = 1 if sampling.lower() == "mwss" else 0
@@ -275,14 +318,17 @@ def forward_transform_jax(
     x = jnp.fft.ifft(x, axis=1, norm="forward")
 
     # PERFORM QUADRATURE CONVOLUTION AS FFT REWEIGHTING IN REAL SPACE
-    x = jnp.einsum("nbm,b->nbm", x, delta[1])
+    # NB: Our convention here is conjugate to that of SSHT, in which
+    # the weights are conjugate but applied flipped and therefore are
+    # equivalent. To avoid flipping here he simply conjugate the weights.
+    x = jnp.einsum("nbm,b->nbm", x, Quads)
 
     # COMPUTE GMM BY FFT
     x = jnp.fft.fft(x, axis=1, norm="forward")
     x = jnp.fft.fftshift(x, axes=1)[:, L - 1 : 3 * L - 2]
 
-    # Calculate flmn = i^(n-m)\sum_t delta^l_tm delta^l_tn G_mnt
-    x = jnp.einsum("nam,lam,lan->nlm", x, delta[0], delta[0][:, :, L - 1 + n])
+    # Calculate flmn = i^(n-m)\sum_t Delta^l_tm Delta^l_tn G_mnt
+    x = jnp.einsum("nam,lam,lan->nlm", x, Delta, Delta[:, :, L - 1 + n])
     x = jnp.einsum("nbm,m,n->nbm", x, 1j ** (m), 1j ** (-n))
 
     # SYMMETRY REFLECT FOR N < 0

--- a/s2fft/precompute_transforms/fourier_wigner.py
+++ b/s2fft/precompute_transforms/fourier_wigner.py
@@ -1,0 +1,298 @@
+from functools import partial
+
+import jax.numpy as jnp
+import numpy as np
+from jax import jit
+
+
+def inverse_transform(
+    flmn: np.ndarray,
+    delta: np.ndarray,
+    L: int,
+    N: int,
+    reality: bool = False,
+    sampling: str = "mw",
+) -> np.ndarray:
+    """
+    Computes the inverse Wigner transform using the Fourier decomposition algorithm.
+
+    Args:
+        flmn (np.ndarray): Wigner coefficients.
+        delta (Tuple[np.ndarray, np.ndarray]): Fourier coefficients of the reduced
+            Wigner d-functions and the corresponding upsampled quadrature weights.
+        L (int): Harmonic band-limit.
+        N (int): Azimuthal band-limit.
+        reality (bool, optional): Whether the signal on the sphere is real.  If so,
+            conjugate symmetry is exploited to reduce computational costs.
+            Defaults to False.
+        sampling (str, optional): Sampling scheme.  Supported sampling schemes include
+            {"mw", "mwss"}. Defaults to "mw".
+
+    Returns:
+        np.ndarray: Pixel-space function sampled on the rotation group.
+
+    """
+    # INDEX VALUES
+    n_start_ind = N - 1 if reality else 0
+    n_dim = N if reality else 2 * N - 1
+    m_offset = 1 if sampling.lower() == "mwss" else 0
+    ntheta = L + 1 if sampling.lower() == "mwss" else L
+    theta0 = 0 if sampling.lower() == "mwss" else np.pi / (2 * L - 1)
+    xnlm_size = 2 * L if sampling.lower() == "mwss" else 2 * L - 1
+
+    # REUSED ARRAYS
+    m = np.arange(-L + 1 - m_offset, L)
+    n = np.arange(n_start_ind - N + 1, N)
+
+    # Calculate fmna = i^(n-m)\sum_L delta^l_am delta^l_an f^l_mn(2l+1)/(8pi^2)
+    x = np.zeros((xnlm_size, xnlm_size, n_dim), dtype=flmn.dtype)
+    x[m_offset:, m_offset:] = np.einsum(
+        "nlm,lam,lan,l->amn",
+        flmn[n_start_ind:],
+        delta[0],
+        delta[0][:, :, L - 1 + n],
+        (2 * np.arange(L) + 1) / (8 * np.pi**2),
+    )
+
+    # APPLY SIGN FUNCTION AND PHASE SHIFT
+    x = np.einsum("amn,m,n,a->nam", x, 1j ** (-m), 1j ** (n), np.exp(1j * m * theta0))
+
+    # PERFORM FFT OVER BETA, GAMMA, ALPHA
+    if reality:
+        x = np.fft.ifftshift(x, axes=(1, 2))
+        x = np.fft.ifft(x, axis=1, norm="forward")[:, :ntheta]
+        x = np.fft.ifft(x, axis=2, norm="forward")
+        return np.fft.irfft(x, 2 * N - 1, axis=0, norm="forward")
+    else:
+        x = np.fft.ifftshift(x)
+        x = np.fft.ifft(x, axis=1, norm="forward")[:, :ntheta]
+        return np.fft.ifft2(x, axes=(0, 2), norm="forward")
+
+
+@partial(jit, static_argnums=(2, 3, 4, 5))
+def inverse_transform_jax(
+    flmn: jnp.ndarray,
+    delta: jnp.ndarray,
+    L: int,
+    N: int,
+    reality: bool = False,
+    sampling: str = "mw",
+) -> jnp.ndarray:
+    """
+    Computes the inverse Wigner transform using the Fourier decomposition algorithm (JAX).
+
+    Args:
+        flmn (jnp.ndarray): Wigner coefficients.
+        delta (Tuple[jnp.ndarray, jnp.ndarray]): Fourier coefficients of the reduced
+            Wigner d-functions and the corresponding upsampled quadrature weights.
+        L (int): Harmonic band-limit.
+        N (int): Azimuthal band-limit.
+        reality (bool, optional): Whether the signal on the sphere is real.  If so,
+            conjugate symmetry is exploited to reduce computational costs.
+            Defaults to False.
+        sampling (str, optional): Sampling scheme.  Supported sampling schemes include
+            {"mw", "mwss"}. Defaults to "mw".
+
+    Returns:
+        jnp.ndarray: Pixel-space function sampled on the rotation group.
+
+    """
+    # INDEX VALUES
+    n_start_ind = N - 1 if reality else 0
+    n_dim = N if reality else 2 * N - 1
+    m_offset = 1 if sampling.lower() == "mwss" else 0
+    ntheta = L + 1 if sampling.lower() == "mwss" else L
+    theta0 = 0 if sampling.lower() == "mwss" else jnp.pi / (2 * L - 1)
+    xnlm_size = 2 * L if sampling.lower() == "mwss" else 2 * L - 1
+
+    # REUSED ARRAYS
+    m = jnp.arange(-L + 1 - m_offset, L)
+    n = jnp.arange(n_start_ind - N + 1, N)
+
+    # Calculate fmna = i^(n-m)\sum_L delta^l_am delta^l_an f^l_mn(2l+1)/(8pi^2)
+    x = jnp.zeros((xnlm_size, xnlm_size, n_dim), dtype=flmn.dtype)
+    x = x.at[m_offset:, m_offset:].set(
+        jnp.einsum(
+            "nlm,lam,lan,l->amn",
+            flmn[n_start_ind:],
+            delta[0],
+            delta[0][:, :, L - 1 + n],
+            (2 * jnp.arange(L) + 1) / (8 * jnp.pi**2),
+        )
+    )
+    # APPLY SIGN FUNCTION AND PHASE SHIFT
+    x = jnp.einsum("amn,m,n,a->nam", x, 1j ** (-m), 1j ** (n), jnp.exp(1j * m * theta0))
+
+    # PERFORM FFT OVER BETA, GAMMA, ALPHA
+    if reality:
+        x = jnp.fft.ifftshift(x, axes=(1, 2))
+        x = jnp.fft.ifft(x, axis=1, norm="forward")[:, :ntheta]
+        x = jnp.fft.ifft(x, axis=2, norm="forward")
+        return jnp.fft.irfft(x, 2 * N - 1, axis=0, norm="forward")
+    else:
+        x = jnp.fft.ifftshift(x)
+        x = jnp.fft.ifft(x, axis=1, norm="forward")[:, :ntheta]
+        return jnp.fft.ifft2(x, axes=(0, 2), norm="forward")
+
+
+def forward_transform(
+    f: np.ndarray, delta: np.ndarray, L: int, N: int, reality: bool, sampling: str
+) -> np.ndarray:
+    """
+    Computes the forward Wigner transform using the Fourier decomposition algorithm.
+
+    Args:
+        f (np.ndarray): Function sampled on the rotation group.
+        delta (Tuple[np.ndarray, np.ndarray]): Fourier coefficients of the reduced
+            Wigner d-functions and the corresponding upsampled quadrature weights.
+        L (int): Harmonic band-limit.
+        N (int): Azimuthal band-limit.
+        reality (bool, optional): Whether the signal on the sphere is real.  If so,
+            conjugate symmetry is exploited to reduce computational costs.
+            Defaults to False.
+        sampling (str, optional): Sampling scheme.  Supported sampling schemes include
+            {"mw", "mwss"}. Defaults to "mw".
+
+    Returns:
+        np.ndarray: Wigner coefficients of function f.
+
+    """
+    # INDEX VALUES
+    n_start_ind = N - 1 if reality else 0
+    m_offset = 1 if sampling.lower() == "mwss" else 0
+    lpad = (L - 2) if sampling.lower() == "mwss" else (L - 1)
+
+    # REUSED ARRAYS
+    m = np.arange(-L + 1, L)
+    n = np.arange(n_start_ind - N + 1, N)
+
+    # COMPUTE ALPHA + GAMMA FFT
+    if reality:
+        x = np.fft.rfft(np.real(f), axis=0, norm="forward")
+        x = np.fft.fft(x, axis=2, norm="forward")
+        x = np.fft.fftshift(x, axes=2)[:, :, m_offset:]
+    else:
+        x = np.fft.fft2(f, axes=(0, 2), norm="forward")
+        x = np.fft.fftshift(x, axes=(0, 2))[:, :, m_offset:]
+
+    # PERIODICALLY EXTEND BETA FROM [0,pi]->[0,2pi)
+    temp = np.einsum("ntm,m,n->ntm", x, (-1) ** np.abs(m), (-1) ** np.abs(n))
+    x = np.concatenate((x, np.flip(temp, axis=1)[:, 1:L]), axis=1)
+
+    # COMPUTE BETA FFT OVER PERIODICALLY EXTENDED FTM
+    x = np.fft.fft(x, axis=1, norm="forward")
+    x = np.fft.fftshift(x, axes=1)
+
+    # APPLY PHASE SHIFT
+    if sampling.lower() == "mw":
+        x = np.einsum("nbm,b->nbm", x, np.exp(-1j * m * np.pi / (2 * L - 1)))
+
+    # FOURIER UPSAMPLE TO 4L-3
+    x = np.pad(x, ((0, 0), (lpad, L - 1), (0, 0)))
+    x = np.fft.ifftshift(x, axes=1)
+    x = np.fft.ifft(x, axis=1, norm="forward")
+
+    # PERFORM QUADRATURE CONVOLUTION AS FFT REWEIGHTING IN REAL SPACE
+    x = np.einsum("nbm,b->nbm", x, delta[1])
+
+    # COMPUTE GMM BY FFT
+    x = np.fft.fft(x, axis=1, norm="forward")
+    x = np.fft.fftshift(x, axes=1)[:, L - 1 : 3 * L - 2]
+
+    # Calculate flmn = i^(n-m)\sum_t delta^l_tm delta^l_tn G_mnt
+    x = np.einsum("nam,lam,lan->nlm", x, delta[0], delta[0][:, :, L - 1 + n])
+    x = np.einsum("nbm,m,n->nbm", x, 1j ** (m), 1j ** (-n))
+
+    # SYMMETRY REFLECT FOR N < 0
+    if reality:
+        temp = np.einsum(
+            "nlm,m,n->nlm",
+            np.conj(np.flip(x[1:], axis=(-1, -3))),
+            (-1) ** np.abs(np.arange(-L + 1, L)),
+            (-1) ** np.abs(np.arange(-N + 1, 0)),
+        )
+        x = np.concatenate((temp, x), axis=0)
+
+    return x * (2.0 * np.pi) ** 2
+
+
+@partial(jit, static_argnums=(2, 3, 4, 5))
+def forward_transform_jax(
+    f: jnp.ndarray, delta: jnp.ndarray, L: int, N: int, reality: bool, sampling: str
+) -> jnp.ndarray:
+    """
+    Computes the forward Wigner transform using the Fourier decomposition algorithm (JAX).
+
+    Args:
+        f (jnp.ndarray): Function sampled on the rotation group.
+        delta (Tuple[jnp.ndarray, jnp.ndarray]): Fourier coefficients of the reduced
+            Wigner d-functions and the corresponding upsampled quadrature weights.
+        L (int): Harmonic band-limit.
+        N (int): Azimuthal band-limit.
+        reality (bool, optional): Whether the signal on the sphere is real.  If so,
+            conjugate symmetry is exploited to reduce computational costs.
+            Defaults to False.
+        sampling (str, optional): Sampling scheme.  Supported sampling schemes include
+            {"mw", "mwss"}. Defaults to "mw".
+
+    Returns:
+        jnp.ndarray: Wigner coefficients of function f.
+
+    """
+    # INDEX VALUES
+    n_start_ind = N - 1 if reality else 0
+    m_offset = 1 if sampling.lower() == "mwss" else 0
+    lpad = (L - 2) if sampling.lower() == "mwss" else (L - 1)
+
+    # REUSED ARRAYS
+    m = jnp.arange(-L + 1, L)
+    n = jnp.arange(n_start_ind - N + 1, N)
+
+    # COMPUTE ALPHA + GAMMA FFT
+    if reality:
+        x = jnp.fft.rfft(jnp.real(f), axis=0, norm="forward")
+        x = jnp.fft.fft(x, axis=2, norm="forward")
+        x = jnp.fft.fftshift(x, axes=2)[:, :, m_offset:]
+    else:
+        x = jnp.fft.fft2(f, axes=(0, 2), norm="forward")
+        x = jnp.fft.fftshift(x, axes=(0, 2))[:, :, m_offset:]
+
+    # PERIODICALLY EXTEND BETA FROM [0,pi]->[0,2pi)
+    temp = jnp.einsum("ntm,m,n->ntm", x, (-1) ** jnp.abs(m), (-1) ** jnp.abs(n))
+    x = jnp.concatenate((x, jnp.flip(temp, axis=1)[:, 1:L]), axis=1)
+
+    # COMPUTE BETA FFT OVER PERIODICALLY EXTENDED FTM
+    x = jnp.fft.fft(x, axis=1, norm="forward")
+    x = jnp.fft.fftshift(x, axes=1)
+
+    # APPLY PHASE SHIFT
+    if sampling.lower() == "mw":
+        x = jnp.einsum("nbm,b->nbm", x, jnp.exp(-1j * m * jnp.pi / (2 * L - 1)))
+
+    # FOURIER UPSAMPLE TO 4L-3
+    x = jnp.pad(x, ((0, 0), (lpad, L - 1), (0, 0)))
+    x = jnp.fft.ifftshift(x, axes=1)
+    x = jnp.fft.ifft(x, axis=1, norm="forward")
+
+    # PERFORM QUADRATURE CONVOLUTION AS FFT REWEIGHTING IN REAL SPACE
+    x = jnp.einsum("nbm,b->nbm", x, delta[1])
+
+    # COMPUTE GMM BY FFT
+    x = jnp.fft.fft(x, axis=1, norm="forward")
+    x = jnp.fft.fftshift(x, axes=1)[:, L - 1 : 3 * L - 2]
+
+    # Calculate flmn = i^(n-m)\sum_t delta^l_tm delta^l_tn G_mnt
+    x = jnp.einsum("nam,lam,lan->nlm", x, delta[0], delta[0][:, :, L - 1 + n])
+    x = jnp.einsum("nbm,m,n->nbm", x, 1j ** (m), 1j ** (-n))
+
+    # SYMMETRY REFLECT FOR N < 0
+    if reality:
+        temp = jnp.einsum(
+            "nlm,m,n->nlm",
+            jnp.conj(jnp.flip(x[1:], axis=(-1, -3))),
+            (-1) ** jnp.abs(jnp.arange(-L + 1, L)),
+            (-1) ** jnp.abs(jnp.arange(-N + 1, 0)),
+        )
+        x = jnp.concatenate((temp, x), axis=0)
+
+    return x * (2.0 * jnp.pi) ** 2

--- a/s2fft/precompute_transforms/wigner.py
+++ b/s2fft/precompute_transforms/wigner.py
@@ -110,7 +110,7 @@ def inverse_transform(
 
     fnab = np.zeros(samples.fnab_shape(L, N, sampling, nside), dtype=np.complex128)
     fnab[n_start_ind:, :, m_offset:] = np.einsum(
-        "...ntlm, ...nlm -> ...ntm", kernel, flmn[n_start_ind:, :, :]
+        "...ntlm, ...nlm -> ...ntm", kernel, flmn[n_start_ind:]
     )
 
     if sampling.lower() in "healpix":
@@ -122,7 +122,6 @@ def inverse_transform(
             return np.fft.irfft(f[n_start_ind:], 2 * N - 1, axis=-2, norm="forward")
         else:
             return np.fft.ifft(np.fft.ifftshift(f, axes=-2), axis=-2, norm="forward")
-
     else:
         if reality:
             fnab = np.fft.ifft(np.fft.ifftshift(fnab, axes=-1), axis=-1, norm="forward")

--- a/tests/test_fourier_wigner.py
+++ b/tests/test_fourier_wigner.py
@@ -1,0 +1,145 @@
+import numpy as np
+import pytest
+import so3
+
+from s2fft.precompute_transforms import construct as c
+from s2fft.precompute_transforms import fourier_wigner as fw
+from s2fft.sampling import so3_samples as samples
+
+# Test cases
+L_to_test = [16]
+N_to_test = [2, 8, 16]
+reality_to_test = [False, True]
+sampling_schemes = ["mw", "mwss"]
+methods_to_test = ["numpy", "jax"]
+
+# Test tolerance
+atol = 1e-12
+
+
+@pytest.mark.parametrize("L", L_to_test)
+@pytest.mark.parametrize("N", N_to_test)
+@pytest.mark.parametrize("sampling", sampling_schemes)
+@pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("method", methods_to_test)
+def test_inverse_fourier_wigner_transform(
+    flmn_generator,
+    s2fft_to_so3_sampling,
+    L: int,
+    N: int,
+    sampling: str,
+    reality: bool,
+    method: str,
+):
+    flmn = flmn_generator(L=L, N=N, reality=reality)
+
+    params = so3.create_parameter_dict(
+        L=L,
+        N=N,
+        sampling_scheme_str=s2fft_to_so3_sampling(sampling),
+        reality=False,
+    )
+    f = so3.inverse(samples.flmn_3d_to_1d(flmn, L, N), params)
+
+    delta = (
+        c.fourier_wigner_kernel_jax(L)
+        if method == "jax"
+        else c.fourier_wigner_kernel(L)
+    )
+    transform = fw.inverse_transform_jax if method == "jax" else fw.inverse_transform
+    f_check = transform(flmn, delta, L, N, reality, sampling)
+    np.testing.assert_allclose(f, f_check.flatten("C"), atol=atol)
+
+
+@pytest.mark.parametrize("L", L_to_test)
+@pytest.mark.parametrize("N", N_to_test)
+@pytest.mark.parametrize("sampling", sampling_schemes)
+@pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("method", methods_to_test)
+def test_forward_fourier_wigner_transform(
+    flmn_generator,
+    s2fft_to_so3_sampling,
+    L: int,
+    N: int,
+    sampling: str,
+    reality: bool,
+    method: str,
+):
+    flmn = flmn_generator(L=L, N=N, reality=reality)
+
+    params = so3.create_parameter_dict(
+        L=L,
+        N=N,
+        sampling_scheme_str=s2fft_to_so3_sampling(sampling),
+        reality=False,
+    )
+    f = so3.inverse(samples.flmn_3d_to_1d(flmn, L, N), params)
+    f_3D = f.reshape(
+        samples._ngamma(N),
+        samples._nbeta(L, sampling),
+        samples._nalpha(L, sampling),
+    )
+    flmn = samples.flmn_1d_to_3d(so3.forward(f, params), L, N)
+
+    delta = (
+        c.fourier_wigner_kernel_jax(L)
+        if method == "jax"
+        else c.fourier_wigner_kernel(L)
+    )
+    transform = fw.forward_transform_jax if method == "jax" else fw.forward_transform
+
+    flmn_check = transform(f_3D, delta, L, N, reality, sampling)
+    np.testing.assert_allclose(flmn, flmn_check, atol=atol)
+
+
+@pytest.mark.parametrize("L", [8, 16, 32, 64])
+@pytest.mark.parametrize("sampling", sampling_schemes)
+@pytest.mark.parametrize("reality", reality_to_test)
+def test_inverse_fourier_wigner_transform_high_N(
+    flmn_generator, s2fft_to_so3_sampling, L: int, sampling: str, reality: bool
+):
+    N = L
+    flmn = flmn_generator(L=L, N=N, reality=reality)
+
+    params = so3.create_parameter_dict(
+        L=L,
+        N=N,
+        sampling_scheme_str=s2fft_to_so3_sampling(sampling),
+        reality=False,
+    )
+    f = so3.inverse(samples.flmn_3d_to_1d(flmn, L, N), params)
+
+    f = f.real if reality else f
+    delta = c.fourier_wigner_kernel(L)
+    f_check = fw.inverse_transform(flmn, delta, L, N, reality, sampling)
+
+    np.testing.assert_allclose(f, f_check.flatten("C"), atol=atol)
+
+
+@pytest.mark.parametrize("L", [8, 16, 32, 64])
+@pytest.mark.parametrize("sampling", sampling_schemes)
+@pytest.mark.parametrize("reality", reality_to_test)
+def test_forward_fourier_wigner_transform_high_N(
+    flmn_generator, s2fft_to_so3_sampling, L: int, sampling: str, reality: bool
+):
+    N = L
+    flmn = flmn_generator(L=L, N=N, reality=reality)
+
+    params = so3.create_parameter_dict(
+        L=L,
+        N=N,
+        sampling_scheme_str=s2fft_to_so3_sampling(sampling),
+        reality=False,
+    )
+
+    f_1D = so3.inverse(samples.flmn_3d_to_1d(flmn, L, N), params)
+    f_3D = f_1D.reshape(
+        samples._ngamma(N),
+        samples._nbeta(L, sampling),
+        samples._nalpha(L, sampling),
+    )
+    flmn_so3 = samples.flmn_1d_to_3d(so3.forward(f_1D, params), L, N)
+
+    delta = c.fourier_wigner_kernel_jax(L)
+    flmn_check = fw.forward_transform_jax(f_3D, delta, L, N, reality, sampling)
+    np.testing.assert_allclose(flmn_so3, flmn_check, atol=atol)


### PR DESCRIPTION
This PR extends the Risbo precompute Wigner transform to the setting where we instead **ONLY** compute the Wigner d coefficients for $\theta = \beta = \pi/2$ which we denote $\Delta^l_{mn} = d^l_{mn}(\pi/2)$. The coefficients for colatitudes other than $\pi/2$ are accessed implicitly at run-time through the Fourier relation outlined by this [McEwen et al 2016](https://arxiv.org/pdf/1508.03101) with further details in this [McEwen et al 2011](http://www.jasonmcewen.org/papers/fssht.pdf).

Ultimately this algorithm costs an extra FFT at run-time but reduces the memory overhead from $\mathcal{O}(NL^3)\sim\mathcal{O}(L^4)$ to $\mathcal{O}(L^3)$. A further reduction in memory by a factor of 8 can be achieved by exploiting the various symmetries of $\Delta^l_{mn}$, however this has yet to be implemented.

As the Risbo recursion is extremely stable we can also consider reduced precision computation (f32, f16, f8) which should recover order ($10^{-8}, 10^{-4}, 10^{-2}$) respectively with corresponding memory reduction and acceleration by a factor of ($2, 4, 8$) respectively.

> [!TIP]
> When building flax layers for $SO(3)$ convolutions using this implementation the dominant memory overhead is entirely independent from the number of channels, so the memory requirement for the precompute transform is fixed.

> [!NOTE] 
> With both the memory reductions from aforementioned symmetry relations and from the switched algorithm, the > precompute algorithm should be runnable at $L \sim 2048$ and potentially slightly beyond. However, this has yet to be tested explicitly.