### PR TITLE
Iterative refinement support for JAX and NumPy forward (spherical) transform implementations

### DIFF
--- a/s2fft/precompute_transforms/spherical.py
+++ b/s2fft/precompute_transforms/spherical.py
@@ -62,14 +62,14 @@ def inverse(
             + "Defering to complex transform.",
             stacklevel=2,
         )
-    if method == "numpy":
-        return inverse_transform(flm, kernel, L, sampling, reality, spin, nside)
-    elif method == "jax":
-        return inverse_transform_jax(flm, kernel, L, sampling, reality, spin, nside)
-    elif method == "torch":
-        return inverse_transform_torch(flm, kernel, L, sampling, reality, spin, nside)
-    else:
+    inverse_functions = {
+        "numpy": inverse_transform,
+        "jax": inverse_transform_jax,
+        "torch": inverse_transform_torch,
+    }
+    if method not in inverse_functions:
         raise ValueError(f"Method {method} not recognised.")
+    return inverse_functions[method](flm, kernel, L, sampling, reality, spin, nside)
 
 
 def inverse_transform(
@@ -337,14 +337,14 @@ def forward(
             + "Defering to complex transform.",
             stacklevel=2,
         )
-    if method == "numpy":
-        return forward_transform(f, kernel, L, sampling, reality, spin, nside)
-    elif method == "jax":
-        return forward_transform_jax(f, kernel, L, sampling, reality, spin, nside)
-    elif method == "torch":
-        return forward_transform_torch(f, kernel, L, sampling, reality, spin, nside)
-    else:
+    forward_functions = {
+        "numpy": forward_transform,
+        "jax": forward_transform_jax,
+        "torch": forward_transform_torch,
+    }
+    if method not in forward_functions:
         raise ValueError(f"Method {method} not recognised.")
+    return forward_functions[method](f, kernel, L, sampling, reality, spin, nside)
 
 
 def forward_transform(

--- a/s2fft/precompute_transforms/spherical.py
+++ b/s2fft/precompute_transforms/spherical.py
@@ -62,6 +62,8 @@ def inverse(
         np.ndarray: Pixel-space coefficients with shape.
 
     """
+    if method not in _inverse_functions:
+        raise ValueError(f"Method {method} not recognised.")
     if reality and spin != 0:
         reality = False
         warn(
@@ -81,8 +83,6 @@ def inverse(
         if kernel is None
         else kernel
     )
-    if method not in _inverse_functions:
-        raise ValueError(f"Method {method} not recognised.")
     return _inverse_functions[method](flm, kernel, **common_kwargs)
 
 
@@ -351,6 +351,8 @@ def forward(
         np.ndarray: Spherical harmonic coefficients.
 
     """
+    if method not in _forward_functions:
+        raise ValueError(f"Method {method} not recognised.")
     if reality and spin != 0:
         reality = False
         warn(
@@ -370,8 +372,6 @@ def forward(
         if kernel is None
         else kernel
     )
-    if method not in _forward_functions:
-        raise ValueError(f"Method {method} not recognised.")
     if iter == 0:
         return _forward_functions[method](f, kernel, **common_kwargs)
     else:

--- a/s2fft/precompute_transforms/spherical.py
+++ b/s2fft/precompute_transforms/spherical.py
@@ -624,7 +624,7 @@ _forward_functions = {
 }
 
 _kernel_functions = {
-    "numpy": partial(construct.fourier_wigner_kernel, using_torch=False),
-    "jax": construct.fourier_wigner_kernel_jax,
-    "torch": partial(construct.fourier_wigner_kernel, using_torch=True),
+    "numpy": partial(construct.spin_spherical_kernel, using_torch=False),
+    "jax": construct.spin_spherical_kernel_jax,
+    "torch": partial(construct.spin_spherical_kernel, using_torch=True),
 }

--- a/s2fft/transforms/otf_recursions.py
+++ b/s2fft/transforms/otf_recursions.py
@@ -82,6 +82,7 @@ def inverse_latitudinal_step(
     if precomps is None:
         precomps = generate_precomputes(L, -mm, sampling, nside, L_lower)
     lrenorm, vsign, cpi, cp2, indices = precomps
+    lrenorm = lrenorm.copy()
 
     for i in range(2):
         if not (reality and i == 0):
@@ -489,6 +490,7 @@ def forward_latitudinal_step(
     if precomps is None:
         precomps = generate_precomputes(L, -mm, sampling, nside, True, L_lower)
     lrenorm, vsign, cpi, cp2, indices = precomps
+    lrenorm = lrenorm.copy()
 
     for i in range(2):
         if not (reality and i == 0):

--- a/s2fft/transforms/otf_recursions.py
+++ b/s2fft/transforms/otf_recursions.py
@@ -82,6 +82,8 @@ def inverse_latitudinal_step(
     if precomps is None:
         precomps = generate_precomputes(L, -mm, sampling, nside, L_lower)
     lrenorm, vsign, cpi, cp2, indices = precomps
+
+    # Create copy to prevent in-place updates propagating to caller
     lrenorm = lrenorm.copy()
 
     for i in range(2):
@@ -490,6 +492,8 @@ def forward_latitudinal_step(
     if precomps is None:
         precomps = generate_precomputes(L, -mm, sampling, nside, True, L_lower)
     lrenorm, vsign, cpi, cp2, indices = precomps
+
+    # Create copy to prevent in-place updates propagating to caller
     lrenorm = lrenorm.copy()
 
     for i in range(2):

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -384,8 +384,11 @@ def forward(
             Primarily of use with HEALPix sampling for which there is not a sampling
             theorem, and round-tripping through the forward and inverse transforms will
             introduce an error. If set to `None`, the default, 3 iterations will be used
-            if :code:`sampling == "healpix"` and :code`method == "jax_healpy"` and zero
-            otherwise. Not used for `jax_ssht` method.
+            if :code:`sampling == "healpix"` and :code:`method == "jax_healpy"` and zero
+            otherwise. For the `healpy` wrappers specifically (that is when
+            :code:`method == "jax_healpy"`) increasing the number iterations increases
+            the accuracy of the forward transform, but reduce the accuracy of the
+            gradient pass. Not used for `jax_ssht` method.
 
         _ssht_backend (int, optional, experimental): Whether to default to SSHT core
             (set to 0) recursions or pick up ducc0 (set to 1) accelerated experimental

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -386,10 +386,7 @@ def forward(
             theorem, and round-tripping through the forward and inverse transforms will
             introduce an error. If set to `None`, the default, 3 iterations will be used
             if :code:`sampling == "healpix"` and :code:`method == "jax_healpy"` and zero
-            otherwise. For the `healpy` wrappers specifically (that is when
-            :code:`method == "jax_healpy"`) increasing the number iterations increases
-            the accuracy of the forward transform, but reduce the accuracy of the
-            gradient pass. Not used for `jax_ssht` method.
+            otherwise. Not used for `jax_ssht` method.
 
         _ssht_backend (int, optional, experimental): Whether to default to SSHT core
             (set to 0) recursions or pick up ducc0 (set to 1) accelerated experimental

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import List
+from typing import List, Optional
 
 import jax.numpy as jnp
 import numpy as np
@@ -336,14 +336,14 @@ def forward(
     f: np.ndarray,
     L: int,
     spin: int = 0,
-    nside: int | None = None,
+    nside: Optional[int] = None,
     sampling: str = "mw",
     method: str = "numpy",
     reality: bool = False,
-    precomps: List | None = None,
+    precomps: Optional[List] = None,
     spmd: bool = False,
     L_lower: int = 0,
-    iter: int | None = None,
+    iter: Optional[int] = None,
     _ssht_backend: int = 1,
 ) -> np.ndarray:
     r"""

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -421,20 +421,18 @@ def forward(
             "nside": nside,
             "sampling": sampling,
             "reality": reality,
-            "precomps": precomps,
             "L_lower": L_lower,
         }
+        forward_kwargs = {**common_kwargs, "precomps": precomps}
+        inverse_kwargs = common_kwargs
         if method in {"jax", "cuda"}:
-            forward_kwargs = {
-                **common_kwargs,
-                "spmd": spmd,
-                "use_healpix_custom_primitive": method == "cuda",
-            }
-            inverse_kwargs = {**common_kwargs, "method": "jax"}
+            forward_kwargs["spmd"] = spmd
+            forward_kwargs["use_healpix_custom_primitive"] = method == "cuda"
+            inverse_kwargs["method"] = "jax"
+            inverse_kwargs["spmd"] = spmd
             forward_function = forward_jax
         else:
-            forward_kwargs = common_kwargs
-            inverse_kwargs = {**common_kwargs, "method": "numpy"}
+            inverse_kwargs["method"] = "numpy"
             forward_function = forward_numpy
         return iterative_refinement.forward_with_iterative_refinement(
             f=f,

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -155,6 +155,9 @@ def inverse_numpy(
     m_start_ind = L - 1 if reality else 0
     L0 = L_lower
 
+    # Copy flm argument to avoid in-place updates being propagated back to caller
+    flm = flm.copy()
+
     # Apply harmonic normalisation
     flm[L0:] = np.einsum(
         "lm,l->lm", flm[L0:], np.sqrt((2 * np.arange(L0, L) + 1) / (4 * np.pi))

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -401,35 +401,22 @@ def forward(
     if spin >= 8 and method in ["numpy", "jax"]:
         raise Warning("Recursive transform may provide lower precision beyond spin ~ 8")
 
-    if method == "numpy":
-        return forward_numpy(f, L, spin, nside, sampling, reality, precomps, L_lower)
-    elif method == "jax":
-        return forward_jax(
-            f,
-            L,
-            spin,
-            nside,
-            sampling,
-            reality,
-            precomps,
-            spmd,
-            L_lower,
-            use_healpix_custom_primitive=False,
-        )
-    elif method == "cuda":
-        return forward_jax(
-            f,
-            L,
-            spin,
-            nside,
-            sampling,
-            reality,
-            precomps,
-            spmd,
-            L_lower,
-            use_healpix_custom_primitive=True,
-        )
-
+    if method in {"numpy", "jax", "cuda"}:
+        kwargs = {
+            "f": f,
+            "L": L,
+            "spin": spin,
+            "nside": nside,
+            "sampling": sampling,
+            "reality": reality,
+            "precomps": precomps,
+            "L_lower": L_lower,
+        }
+        if method in {"jax", "cuda"}:
+            kwargs["spmd"] = spmd
+            kwargs["use_healpix_custom_primitive"] = method == "cuda"
+        forward_function = forward_numpy if method == "numpy" else forward_jax
+        return forward_function(**kwargs)
     elif method == "jax_ssht":
         if sampling.lower() == "healpix":
             raise ValueError("SSHT does not support healpix sampling.")

--- a/s2fft/utils/__init__.py
+++ b/s2fft/utils/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     healpix_ffts,
+    iterative_refinement,
     jax_primitive,
     quadrature,
     quadrature_jax,

--- a/s2fft/utils/iterative_refinement.py
+++ b/s2fft/utils/iterative_refinement.py
@@ -1,7 +1,6 @@
 """Iterative scheme for improving accuracy of linear transforms."""
 
-from collections.abc import Callable
-from typing import TypeVar
+from typing import Callable, TypeVar
 
 T = TypeVar("T")
 

--- a/s2fft/utils/iterative_refinement.py
+++ b/s2fft/utils/iterative_refinement.py
@@ -1,0 +1,46 @@
+"""Iterative scheme for improving accuracy of linear transforms."""
+
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def forward_with_iterative_refinement(
+    f: T,
+    n_iter: int,
+    forward_function: Callable[[T], T],
+    backward_function: Callable[[T], T],
+) -> T:
+    """
+    Apply forward transform with iterative refinement to improve accuracy.
+
+    `Iterative refinement <https://en.wikipedia.org/wiki/Iterative_refinement>`_ is a
+    general approach for improving the accuracy of numerial solutions to linear systems.
+    In the context of spherical harmonic transforms, given a forward transform which is
+    an _approximate_ inverse to a corresponding backward ('inverse') transform,
+    iterative refinement allows defining an iterative forward transform which is a more
+    accurate
+
+    Args:
+        f: Array argument to forward transform (signal on sphere) to compute iteratively
+           refined forward transform at.
+
+        n_iter: Number of refinement iterations to use, non-negative.
+
+        forward_function: Function computing forward transform (approximate inverse of
+            backward transform).
+
+        backward_function: Function computing backward ('inverse') transform.
+
+    Returns:
+        Array output from iteratively refined forward transform (spherical harmonic
+        coefficients).
+
+    """
+    flm = forward_function(f)
+    for _ in range(n_iter):
+        f_recov = backward_function(flm)
+        f_error = f - f_recov
+        flm += forward_function(f_error)
+    return flm

--- a/tests/test_spherical_custom_grads.py
+++ b/tests/test_spherical_custom_grads.py
@@ -161,6 +161,7 @@ def test_healpix_inverse_custom_gradients(
 @pytest.mark.parametrize("L_lower", L_lower_to_test)
 @pytest.mark.parametrize("spin", spin_to_test)
 @pytest.mark.parametrize("reality", reality_to_test)
+@pytest.mark.parametrize("iter", [0, 1, 2, 3])
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_healpix_forward_custom_gradients(
     flm_generator,
@@ -168,6 +169,7 @@ def test_healpix_forward_custom_gradients(
     L_lower: int,
     spin: int,
     reality: bool,
+    iter: int,
 ):
     sampling = "healpix"
     L = 2 * nside
@@ -191,15 +193,17 @@ def test_healpix_forward_custom_gradients(
     )
 
     def func(f):
-        flm = spherical.forward_jax(
+        flm = spherical.forward(
             f,
             L,
+            method="jax",
             spin=spin,
             nside=nside,
             L_lower=L_lower,
             reality=reality,
             precomps=precomps,
             sampling=sampling,
+            iter=iter,
         )
         return jnp.sum(jnp.abs(flm - flm_target) ** 2)
 

--- a/tests/test_spherical_precompute.py
+++ b/tests/test_spherical_precompute.py
@@ -324,3 +324,19 @@ def test_transform_forward_high_spin(
     flm_recov = forward(f, L, spin, kernel, sampling, reality, "numpy")
     tol = 1e-8 if sampling.lower() in ["dh", "gl"] else 1e-12
     np.testing.assert_allclose(flm_recov, flm, atol=tol, rtol=tol)
+
+
+def test_forward_transform_unrecognised_method_raises():
+    method = "invalid_method"
+    L = 32
+    f = np.zeros(samples.f_shape(L))
+    with pytest.raises(ValueError, match=f"{method} not recognised"):
+        forward(f, L, method=method)
+
+
+def test_inverse_transform_unrecognised_method_raises():
+    method = "invalid_method"
+    L = 32
+    flm = np.zeros(samples.flm_shape(L))
+    with pytest.raises(ValueError, match=f"{method} not recognised"):
+        inverse(flm, L, method=method)

--- a/tests/test_spherical_precompute.py
+++ b/tests/test_spherical_precompute.py
@@ -1,3 +1,4 @@
+import jax
 import numpy as np
 import pyssht as ssht
 import pytest
@@ -7,6 +8,8 @@ from s2fft.base_transforms import spherical as base
 from s2fft.precompute_transforms import construct as c
 from s2fft.precompute_transforms.spherical import forward, inverse
 from s2fft.sampling import s2_samples as samples
+
+jax.config.update("jax_enable_x64", True)
 
 # Maximum spin number at which Price-McEwen recursion is sufficiently accurate.
 # For spins > PM_MAX_STABLE_SPIN one should default to the Risbo recursion.
@@ -20,6 +23,7 @@ sampling_to_test = ["mw", "mwss", "dh", "gl"]
 reality_to_test = [True, False]
 methods_to_test = ["numpy", "jax", "torch"]
 recursions_to_test = ["price-mcewen", "risbo", "auto"]
+iter_to_test = [0, 3]
 
 
 @pytest.mark.parametrize("L", L_to_test)
@@ -221,6 +225,7 @@ def test_transform_forward(
 @pytest.mark.parametrize("reality", reality_to_test)
 @pytest.mark.parametrize("method", methods_to_test)
 @pytest.mark.parametrize("recursion", recursions_to_test)
+@pytest.mark.parametrize("iter", iter_to_test)
 def test_transform_forward_healpix(
     flm_generator,
     nside: int,
@@ -228,12 +233,13 @@ def test_transform_forward_healpix(
     reality: bool,
     method: str,
     recursion: str,
+    iter: int,
 ):
     sampling = "healpix"
     L = ratio * nside
     flm = flm_generator(L=L, reality=True)
     f = base.inverse(flm, L, 0, sampling, nside, reality)
-    flm_check = base.forward(f, L, 0, sampling, nside, reality)
+    flm_check = base.forward(f, L, 0, sampling, nside, reality, iter=iter)
 
     kfunc = (
         c.spin_spherical_kernel_jax
@@ -254,6 +260,7 @@ def test_transform_forward_healpix(
             reality,
             method,
             nside,
+            iter,
         )
         np.testing.assert_allclose(flm_recov, flm_check, atol=tol, rtol=tol)
 
@@ -271,10 +278,11 @@ def test_transform_forward_healpix(
                 reality,
                 method,
                 nside,
+                iter,
             ),
         )
     else:
-        flm_recov = forward(f, L, 0, kernel, sampling, reality, method, nside)
+        flm_recov = forward(f, L, 0, kernel, sampling, reality, method, nside, iter)
         np.testing.assert_allclose(flm_recov, flm_check, atol=tol, rtol=tol)
 
 

--- a/tests/test_spherical_transform.py
+++ b/tests/test_spherical_transform.py
@@ -150,12 +150,14 @@ def test_transform_forward(
 @pytest.mark.parametrize("nside", nside_to_test)
 @pytest.mark.parametrize("method", method_to_test)
 @pytest.mark.parametrize("spmd", multiple_gpus)
+@pytest.mark.parametrize("iter", [0, 1, 2, 3])
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_transform_forward_healpix(
     flm_generator,
     nside: int,
     method: str,
     spmd: bool,
+    iter: int,
 ):
     sampling = "healpix"
     L = 2 * nside
@@ -174,10 +176,11 @@ def test_transform_forward_healpix(
         reality=True,
         precomps=precomps,
         spmd=spmd,
+        iter=iter,
     )
     flm_check = samples.flm_2d_to_hp(flm_check, L)
 
-    flm = hp.sphtfunc.map2alm(f, lmax=L - 1, iter=0)
+    flm = hp.sphtfunc.map2alm(f, lmax=L - 1, iter=iter)
 
     np.testing.assert_allclose(flm, flm_check, atol=1e-14)
 


### PR DESCRIPTION
Should resolve #139 

Adds support for using `iter` keyword argument to `s2fft.forward` when using `method = "numpy"` and `method = "jax"`, using an [iterative refinement](https://en.wikipedia.org/wiki/Iterative_refinement) approach equivalent to that implemented in `healpy` to improve accuracy of forward transform (in terms of acting as the inverse of the inverse transform). 

Currently this is only added for spherical transform, and is available for all sampling types, even though in practice probably only useful for HEALPix (though `iter=1` does seem to give a small gain in accuracy for other sampling types).