### PR TITLE
Avoid loops in `s2fft.sampling.reindex` functions to reduce compile and run times

### DIFF
--- a/s2fft/sampling/reindex.py
+++ b/s2fft/sampling/reindex.py
@@ -8,7 +8,7 @@ from jax import jit
 @partial(jit, static_argnums=(1))
 def flm_1d_to_2d_fast(flm_1d: jnp.ndarray, L: int) -> jnp.ndarray:
     r"""
-    Convert from 1D indexed harmnonic coefficients to 2D indexed coefficients (JAX).
+    Convert from 1D indexed harmonic coefficients to 2D indexed coefficients (JAX).
     
     Note:
         Storage conventions for harmonic coefficients :math:`flm_{(\ell,m)}`, for 
@@ -36,7 +36,7 @@ def flm_1d_to_2d_fast(flm_1d: jnp.ndarray, L: int) -> jnp.ndarray:
         jnp.ndarray: 2D indexed harmonic coefficients.
 
     """
-    flm_2d = jnp.zeros((L, 2 * L - 1), dtype=jnp.complex128)
+    flm_2d = jnp.zeros((L, 2 * L - 1), dtype=flm_1d.dtype)
     row_indices, col_indices = np.arange(L)[:, None], np.arange(2 * L - 1)[None, :]
     el_indices, m_indices = np.where(
         (row_indices <= col_indices)[::-1, :] & (row_indices <= col_indices)[::-1, ::-1]

--- a/s2fft/sampling/reindex.py
+++ b/s2fft/sampling/reindex.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 import jax.numpy as jnp
+import numpy as np
 from jax import jit
 
 
@@ -36,12 +37,11 @@ def flm_1d_to_2d_fast(flm_1d: jnp.ndarray, L: int) -> jnp.ndarray:
 
     """
     flm_2d = jnp.zeros((L, 2 * L - 1), dtype=jnp.complex128)
-    els = jnp.arange(L)
-    offset = els**2 + els
-    for el in range(L):
-        m_array = jnp.arange(-el, el + 1)
-        flm_2d = flm_2d.at[el, L - 1 + m_array].set(flm_1d[offset[el] + m_array])
-    return flm_2d
+    row_indices, col_indices = np.arange(L)[:, None], np.arange(2 * L - 1)[None, :]
+    el_indices, m_indices = np.where(
+        (row_indices <= col_indices)[::-1, :] & (row_indices <= col_indices)[::-1, ::-1]
+    )
+    return flm_2d.at[el_indices, m_indices].set(flm_1d)
 
 
 @partial(jit, static_argnums=(1))
@@ -75,13 +75,11 @@ def flm_2d_to_1d_fast(flm_2d: jnp.ndarray, L: int) -> jnp.ndarray:
         jnp.ndarray: 1D indexed harmonic coefficients.
 
     """
-    flm_1d = jnp.zeros(L**2, dtype=jnp.complex128)
-    els = jnp.arange(L)
-    offset = els**2 + els
-    for el in range(L):
-        m_array = jnp.arange(-el, el + 1)
-        flm_1d = flm_1d.at[offset[el] + m_array].set(flm_2d[el, L - 1 + m_array])
-    return flm_1d
+    row_indices, col_indices = np.arange(L)[:, None], np.arange(2 * L - 1)[None, :]
+    el_indices, m_indices = np.where(
+        (row_indices <= col_indices)[::-1, :] & (row_indices <= col_indices)[::-1, ::-1]
+    )
+    return flm_2d[el_indices, m_indices]
 
 
 @partial(jit, static_argnums=(1))
@@ -127,17 +125,12 @@ def flm_hp_to_2d_fast(flm_hp: jnp.ndarray, L: int) -> jnp.ndarray:
         jnp.ndarray: 2D indexed harmonic coefficients.
 
     """
-    flm_2d = jnp.zeros((L, 2 * L - 1), dtype=jnp.complex128)
-
-    for el in range(L):
-        flm_2d = flm_2d.at[el, L - 1].set(flm_hp[el])
-        m_array = jnp.arange(1, el + 1)
-        hp_idx = m_array * (2 * L - 1 - m_array) // 2 + el
-        flm_2d = flm_2d.at[el, L - 1 + m_array].set(flm_hp[hp_idx])
-        flm_2d = flm_2d.at[el, L - 1 - m_array].set(
-            (-1) ** m_array * jnp.conj(flm_hp[hp_idx])
-        )
-
+    flm_2d = jnp.zeros((L, 2 * L - 1), dtype=flm_hp.dtype)
+    m_indices, el_indices = np.triu_indices(n=L + 1, m=L)
+    flm_2d = flm_2d.at[el_indices, L - 1 + m_indices].set(flm_hp)
+    flm_2d = flm_2d.at[el_indices, L - 1 - m_indices].set(
+        (-1) ** m_indices * flm_hp.conj()
+    )
     return flm_2d
 
 
@@ -185,11 +178,5 @@ def flm_2d_to_hp_fast(flm_2d: jnp.ndarray, L: int) -> jnp.ndarray:
         jnp.ndarray: HEALPix indexed harmonic coefficients.
 
     """
-    flm_hp = jnp.zeros(int(L * (L + 1) / 2), dtype=jnp.complex128)
-
-    for el in range(L):
-        m_array = jnp.arange(el + 1)
-        hp_idx = m_array * (2 * L - 1 - m_array) // 2 + el
-        flm_hp = flm_hp.at[hp_idx].set(flm_2d[el, L - 1 + m_array])
-
-    return flm_hp
+    m_indices, el_indices = np.triu_indices(n=L + 1, m=L)
+    return flm_2d[el_indices, L - 1 + m_indices]

--- a/s2fft/sampling/reindex.py
+++ b/s2fft/sampling/reindex.py
@@ -126,10 +126,11 @@ def flm_hp_to_2d_fast(flm_hp: jnp.ndarray, L: int) -> jnp.ndarray:
 
     """
     flm_2d = jnp.zeros((L, 2 * L - 1), dtype=flm_hp.dtype)
-    m_indices, el_indices = np.triu_indices(n=L + 1, m=L)
-    flm_2d = flm_2d.at[el_indices, L - 1 + m_indices].set(flm_hp)
+    m_indices, el_indices = np.triu_indices(n=L, k=1, m=L) + np.array([[1], [0]])
+    flm_2d = flm_2d.at[:L, L - 1].set(flm_hp[:L])
+    flm_2d = flm_2d.at[el_indices, L - 1 + m_indices].set(flm_hp[L:])
     flm_2d = flm_2d.at[el_indices, L - 1 - m_indices].set(
-        (-1) ** m_indices * flm_hp.conj()
+        (-1) ** m_indices * flm_hp[L:].conj()
     )
     return flm_2d
 


### PR DESCRIPTION
The index conversion functions in `s2fft.sampling.reindex` currently use Python loops (over `L` iterations) to perform the reindexing operations slice by slice. As these loops are unrolled when JIT compiling this leads to long compile times as `L` gets bigger.

This PR refactors the reindexing functions to instead construct arrays of indices and use these to gather or scatter the relevant entries in single indexing operations, thus avoiding the loops. For the functions converting between HEALPix and 2D harmonic coefficient indexing, we can use the `numpy.triu_indices` function to construct the relevant index arrays. For the maps between 1D and 2D layouts we can use `numpy.where` on a boolean array constructed so that the relevant array elements are `True`.  In both cases the explicitly constructed index arrays add some memory overhead - as they depend only `L` which is static they will be constants at compile time, and in all cases are I believe $\mathcal{O}(L^2)$ in size - however this is no larger than the memory requirements of the harmonic coefficient arrays themselves, and the computational graphs of the resulting compiled functions are much smaller (no longer scaling with `L`) so its unclear if overall the memory requirements are much larger.

I've done some benchmarking of the new implementations here compared to the current implementations and in all cases tested the compile times are significantly lower and the run times comparable or significantly better:

https://gist.github.com/matt-graham/7a2b5b77f51b5301b8910ced176d8a8a

For example for the `flm_2d_to_hp_fast` function, the following plot shows the compile times of the current implementation ("Current"), the proposed implementation ("triu_indices based") and two other alternatives I tried out ("Slice based" and "Nested fori_loop") for various `L` values

![flm_2d_to_hp compile time comparison](https://github.com/user-attachments/assets/0d575014-9e07-469d-bedb-f16115fef0c1)

and the corresponding plot for run times of the compiled functions

![flm_2d_to_hp run time comparison](https://github.com/user-attachments/assets/29d96e63-5075-4fde-acdb-b9091b07eff3)

On both compile and run times the proposed "triu_indices based" implementation is significantly quicker than both the current implementation and the other alternatives considered.

EDIT: There was a slight bug in the `flm_hp_to_2d_fast` reimplementation now hopefully fixed. The run times for the new function are now a little slower but the compile time is still much better than current implementation and importantly not quickly growing with `L`.
