### PR TITLE
Improvements to benchmarking system

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,15 +8,24 @@ and/or systems.
 If the [`memory_profiler` package](https://github.com/pythonprofilers/memory_profiler) 
 is installed an estimate of the peak (main) memory usage of the benchmarked functions
 will also be recorded.
+If the [`py-cpuinfo` package](https://pypi.org/project/py-cpuinfo/) 
+is installed additional information about CPU of system benchmarks are run on will be
+recorded in JSON output.
 
 
 ## Description
 
 The benchmark scripts are as follows:
 
-  * `wigner.py` contains benchmarks for Wigner transforms (forward and inverse)
-  * `spherical.py` contains benchmarks for spherical transforms (forward and inverse)
-
+  * `spherical.py` contains benchmarks for on-the-fly implementations of spherical 
+    transforms (forward and inverse).
+  * `precompute_spherical.py` contains benchmarks for precompute implementations of
+    spherical transforms (forward and inverse).
+  * `wigner.py` contains benchmarks for on-the-fly implementations of Wigner-d
+    transforms (forward and inverse).
+  * `precompute_wigner.py` contains benchmarks for precompute implementations of
+    Wigner-d transforms (forward and inverse).
+  
 The `benchmarking.py` module contains shared utility functions for defining and running
 the benchmarks.
 
@@ -29,22 +38,26 @@ the JSON formatted benchmark results to. Pass a `--help` argument to the script 
 display the usage message:
 
 ```
-usage: Run benchmarks [-h] [-number-runs NUMBER_RUNS] [-repeats REPEATS]
-                      [-parameter-overrides [PARAMETER_OVERRIDES [PARAMETER_OVERRIDES ...]]]
-                      [-output-file OUTPUT_FILE]
+usage: spherical.py [-h] [-number-runs NUMBER_RUNS] [-repeats REPEATS]
+                    [-parameter-overrides [PARAMETER_OVERRIDES ...]] [-output-file OUTPUT_FILE]
+                    [--run-once-and-discard]
 
-optional arguments:
+Benchmarks for on-the-fly spherical transforms.
+
+options:
   -h, --help            show this help message and exit
   -number-runs NUMBER_RUNS
-                        Number of times to run the benchmark in succession in each
-                        timing run.
-  -repeats REPEATS      Number of times to repeat the benchmark runs.
-  -parameter-overrides [PARAMETER_OVERRIDES [PARAMETER_OVERRIDES ...]]
-                        Override for values to use for benchmark parameter. A parameter
-                        name followed by space separated list of values to use. May be
-                        specified multiple times to override multiple parameters.
+                        Number of times to run the benchmark in succession in each timing run. (default: 10)
+  -repeats REPEATS      Number of times to repeat the benchmark runs. (default: 3)
+  -parameter-overrides [PARAMETER_OVERRIDES ...]
+                        Override for values to use for benchmark parameter. A parameter name followed by space
+                        separated list of values to use. May be specified multiple times to override multiple
+                        parameters. (default: None)
   -output-file OUTPUT_FILE
-                        File path to write JSON formatted results to.
+                        File path to write JSON formatted results to. (default: None)
+  --run-once-and-discard
+                        Run benchmark function once first without recording time to ignore the effect of any initial
+                        one-off costs such as just-in-time compilation. (default: False)
 ```
 
 For example to run the spherical transform benchmarks using only the JAX implementations,
@@ -52,7 +65,7 @@ running on a CPU (in double-precision) for `L` values 64, 128, 256, 512 and 1024
 would run from the root of the repository:
 
 ```sh
-JAX_PLATFORM_NAME=cpu JAX_ENABLE_X64=1 python benchmarks/spherical.py -p L 64 128 256 512 1024 -p method jax
+JAX_PLATFORM_NAME=cpu JAX_ENABLE_X64=1 python benchmarks/spherical.py --run-once-and-discard -p L 64 128 256 512 1024 -p method jax
 ```
 
 Note the usage of environment variables `JAX_PLATFORM_NAME` and `JAX_ENABLE_X64` to 

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -239,7 +239,7 @@ def run_benchmarks(
     """
     results = {}
     for benchmark in benchmarks:
-        results[benchmark.__name__] = {}
+        results[benchmark.__name__] = []
         if print_results:
             print(benchmark.__name__)
         parameters = benchmark.parameters.copy()
@@ -257,7 +257,7 @@ def run_benchmarks(
                         benchmark_function, number=number_runs, repeat=number_repeats
                     )
                 ]
-                results[benchmark.__name__] = {**parameter_set, "times / s": run_times}
+                results_entry = {**parameter_set, "times / s": run_times}
                 if MEMORY_PROFILER_AVAILABLE:
                     baseline_memory = memory_profiler.memory_usage(max_usage=True)
                     peak_memory = (
@@ -270,7 +270,8 @@ def run_benchmarks(
                         )
                         - baseline_memory
                     )
-                    results[benchmark.__name__]["peak_memory / MiB"] = peak_memory
+                    results_entry["peak_memory / MiB"] = peak_memory
+                results[benchmark.__name__].append(results_entry)
                 if print_results:
                     print(
                         (
@@ -279,9 +280,9 @@ def run_benchmarks(
                             else "    "
                         )
                         + f"min(time): {min(run_times):>#7.2g}s, "
-                        + f"max(time): {max(run_times):>#7.2g}s, "
+                        + f"max(time): {max(run_times):>#7.2g}s"
                         + (
-                            f"peak mem.: {peak_memory:>#7.2g}MiB"
+                            f", peak mem.: {peak_memory:>#7.2g}MiB"
                             if MEMORY_PROFILER_AVAILABLE
                             else ""
                         )

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -145,10 +145,10 @@ def _parse_parameter_overrides(parameter_overrides):
     )
 
 
-def _parse_cli_arguments():
+def _parse_cli_arguments(description):
     """Parse command line arguments passed for controlling benchmark runs"""
     parser = argparse.ArgumentParser(
-        "Run benchmarks", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        description=description, formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument(
         "-number-runs",
@@ -305,11 +305,11 @@ def parse_args_collect_and_run_benchmarks(module=None):
         Dictionary containing timing (and potentially memory usage) results for each
         parameters set of each benchmark function.
     """
-    args = _parse_cli_arguments()
-    parameter_overrides = _parse_parameter_overrides(args.parameter_overrides)
     if module is None:
         frame = inspect.stack()[1]
         module = inspect.getmodule(frame[0])
+    args = _parse_cli_arguments(module.__doc__)
+    parameter_overrides = _parse_parameter_overrides(args.parameter_overrides)
     results = run_benchmarks(
         benchmarks=collect_benchmarks(module),
         number_runs=args.number_runs,

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -147,7 +147,9 @@ def _parse_parameter_overrides(parameter_overrides):
 
 def _parse_cli_arguments():
     """Parse command line arguments passed for controlling benchmark runs"""
-    parser = argparse.ArgumentParser("Run benchmarks")
+    parser = argparse.ArgumentParser(
+        "Run benchmarks", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument(
         "-number-runs",
         type=int,

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -91,6 +91,26 @@ def _get_version_or_none(package_name):
         return None
 
 
+def _get_cpu_info():
+    """Get details of CPU from cpuinfo if available or None if not."""
+    try:
+        import cpuinfo
+
+        return cpuinfo.get_cpu_info()
+    except ImportError:
+        return None
+
+
+def _get_gpu_info():
+    """Get details of GPU devices available from JAX or None if JAX not available."""
+    try:
+        import jax
+
+        return [d.device_kind for d in jax.devices() if d.platform == "gpu"]
+    except ImportError:
+        return None
+
+
 def skip(message):
     """Skip benchmark for a particular parameter set with explanatory message.
 
@@ -342,11 +362,14 @@ def parse_args_collect_and_run_benchmarks(module=None):
             "python_version": platform.python_version(),
             "release": platform.release(),
             "system": platform.system(),
+            "cpu_info": _get_cpu_info(),
+            "gpu_info": _get_gpu_info(),
             **package_versions,
         }
         with open(args.output_file, "w") as f:
             output = {
                 "date_time": datetime.datetime.now().isoformat(),
+                "benchmark_module": module.__name__,
                 "system_info": system_info,
                 "results": results,
             }

--- a/benchmarks/precompute_spherical.py
+++ b/benchmarks/precompute_spherical.py
@@ -1,0 +1,102 @@
+"""Benchmarks for spherical transforms."""
+
+import numpy as np
+import pyssht
+from benchmarking import benchmark, parse_args_collect_and_run_benchmarks, skip
+
+import s2fft
+import s2fft.precompute_transforms
+from s2fft.sampling import s2_samples as samples
+
+L_VALUES = [8, 16, 32, 64, 128, 256]
+SPIN_VALUES = [0]
+SAMPLING_VALUES = ["mw"]
+METHOD_VALUES = ["numpy", "jax"]
+REALITY_VALUES = [True]
+
+
+def setup_forward(method, L, sampling, spin, reality):
+    if reality and spin != 0:
+        skip("Reality only valid for scalar fields (spin=0).")
+    rng = np.random.default_rng()
+    flm = s2fft.utils.signal_generator.generate_flm(rng, L, spin=spin, reality=reality)
+    f = pyssht.inverse(
+        samples.flm_2d_to_1d(flm, L),
+        L,
+        Method=sampling.upper(),
+        Spin=spin,
+        Reality=reality,
+    )
+    kernel_function = (
+        s2fft.precompute_transforms.construct.spin_spherical_kernel_jax
+        if method == "jax"
+        else s2fft.precompute_transforms.construct.spin_spherical_kernel
+    )
+    kernel = kernel_function(
+        L=L, spin=spin, reality=reality, sampling=sampling, forward=True
+    )
+    return {"f": f, "kernel": kernel}
+
+
+@benchmark(
+    setup_forward,
+    method=METHOD_VALUES,
+    L=L_VALUES,
+    sampling=SAMPLING_VALUES,
+    spin=SPIN_VALUES,
+    reality=REALITY_VALUES,
+)
+def forward(f, kernel, method, L, sampling, spin, reality):
+    flm = s2fft.precompute_transforms.spherical.forward(
+        f=f,
+        L=L,
+        spin=spin,
+        kernel=kernel,
+        sampling=sampling,
+        reality=reality,
+        method=method,
+    )
+    if method == "jax":
+        flm.block_until_ready()
+
+
+def setup_inverse(method, L, sampling, spin, reality):
+    if reality and spin != 0:
+        skip("Reality only valid for scalar fields (spin=0).")
+    rng = np.random.default_rng()
+    flm = s2fft.utils.signal_generator.generate_flm(rng, L, spin=spin, reality=reality)
+    kernel_function = (
+        s2fft.precompute_transforms.construct.spin_spherical_kernel_jax
+        if method == "jax"
+        else s2fft.precompute_transforms.construct.spin_spherical_kernel
+    )
+    kernel = kernel_function(
+        L=L, spin=spin, reality=reality, sampling=sampling, forward=False
+    )
+    return {"flm": flm, "kernel": kernel}
+
+
+@benchmark(
+    setup_inverse,
+    method=METHOD_VALUES,
+    L=L_VALUES,
+    sampling=SAMPLING_VALUES,
+    spin=SPIN_VALUES,
+    reality=REALITY_VALUES,
+)
+def inverse(flm, kernel, method, L, sampling, spin, reality):
+    f = s2fft.precompute_transforms.spherical.inverse(
+        flm=flm,
+        L=L,
+        spin=spin,
+        kernel=kernel,
+        sampling=sampling,
+        reality=reality,
+        method=method,
+    )
+    if method == "jax":
+        f.block_until_ready()
+
+
+if __name__ == "__main__":
+    results = parse_args_collect_and_run_benchmarks()

--- a/benchmarks/precompute_spherical.py
+++ b/benchmarks/precompute_spherical.py
@@ -13,9 +13,10 @@ SPIN_VALUES = [0]
 SAMPLING_VALUES = ["mw"]
 METHOD_VALUES = ["numpy", "jax"]
 REALITY_VALUES = [True]
+RECURSION_VALUES = ["auto"]
 
 
-def setup_forward(method, L, sampling, spin, reality):
+def setup_forward(method, L, sampling, spin, reality, recursion):
     if reality and spin != 0:
         skip("Reality only valid for scalar fields (spin=0).")
     rng = np.random.default_rng()
@@ -33,7 +34,12 @@ def setup_forward(method, L, sampling, spin, reality):
         else s2fft.precompute_transforms.construct.spin_spherical_kernel
     )
     kernel = kernel_function(
-        L=L, spin=spin, reality=reality, sampling=sampling, forward=True
+        L=L,
+        spin=spin,
+        reality=reality,
+        sampling=sampling,
+        forward=True,
+        recursion=recursion,
     )
     return {"f": f, "kernel": kernel}
 
@@ -45,8 +51,9 @@ def setup_forward(method, L, sampling, spin, reality):
     sampling=SAMPLING_VALUES,
     spin=SPIN_VALUES,
     reality=REALITY_VALUES,
+    recursion=RECURSION_VALUES,
 )
-def forward(f, kernel, method, L, sampling, spin, reality):
+def forward(f, kernel, method, L, sampling, spin, reality, recursion):
     flm = s2fft.precompute_transforms.spherical.forward(
         f=f,
         L=L,
@@ -60,7 +67,7 @@ def forward(f, kernel, method, L, sampling, spin, reality):
         flm.block_until_ready()
 
 
-def setup_inverse(method, L, sampling, spin, reality):
+def setup_inverse(method, L, sampling, spin, reality, recursion):
     if reality and spin != 0:
         skip("Reality only valid for scalar fields (spin=0).")
     rng = np.random.default_rng()
@@ -71,7 +78,12 @@ def setup_inverse(method, L, sampling, spin, reality):
         else s2fft.precompute_transforms.construct.spin_spherical_kernel
     )
     kernel = kernel_function(
-        L=L, spin=spin, reality=reality, sampling=sampling, forward=False
+        L=L,
+        spin=spin,
+        reality=reality,
+        sampling=sampling,
+        forward=False,
+        recursion=recursion,
     )
     return {"flm": flm, "kernel": kernel}
 
@@ -83,8 +95,9 @@ def setup_inverse(method, L, sampling, spin, reality):
     sampling=SAMPLING_VALUES,
     spin=SPIN_VALUES,
     reality=REALITY_VALUES,
+    recursion=RECURSION_VALUES,
 )
-def inverse(flm, kernel, method, L, sampling, spin, reality):
+def inverse(flm, kernel, method, L, sampling, spin, reality, recursion):
     f = s2fft.precompute_transforms.spherical.inverse(
         flm=flm,
         L=L,

--- a/benchmarks/precompute_spherical.py
+++ b/benchmarks/precompute_spherical.py
@@ -1,4 +1,4 @@
-"""Benchmarks for spherical transforms."""
+"""Benchmarks for precompute spherical transforms."""
 
 import numpy as np
 import pyssht

--- a/benchmarks/precompute_wigner.py
+++ b/benchmarks/precompute_wigner.py
@@ -14,8 +14,10 @@ L_LOWER_VALUES = [0]
 SAMPLING_VALUES = ["mw"]
 METHOD_VALUES = ["numpy", "jax"]
 REALITY_VALUES = [True]
+MODE_VALUES = ["auto"]
 
-def setup_forward(method, L, N, L_lower, sampling, reality):
+
+def setup_forward(method, L, N, L_lower, sampling, reality, mode):
     rng = np.random.default_rng()
     flmn = s2fft.utils.signal_generator.generate_flmn(rng, L, N, reality=reality)
     f = base_wigner.inverse(
@@ -32,7 +34,7 @@ def setup_forward(method, L, N, L_lower, sampling, reality):
         else s2fft.precompute_transforms.construct.wigner_kernel
     )
     kernel = kernel_function(
-        L=L, N=N, reality=reality, sampling=sampling, forward=True
+        L=L, N=N, reality=reality, sampling=sampling, forward=True, mode=mode
     )
     return {"f": f, "kernel": kernel}
 
@@ -45,8 +47,9 @@ def setup_forward(method, L, N, L_lower, sampling, reality):
     L_lower=L_LOWER_VALUES,
     sampling=SAMPLING_VALUES,
     reality=REALITY_VALUES,
+    mode=MODE_VALUES,
 )
-def forward(f, kernel, method, L, N, L_lower, sampling, reality):
+def forward(f, kernel, method, L, N, L_lower, sampling, reality, mode):
     flmn = s2fft.precompute_transforms.wigner.forward(
         f=f,
         L=L,
@@ -60,7 +63,7 @@ def forward(f, kernel, method, L, N, L_lower, sampling, reality):
         flmn.block_until_ready()
 
 
-def setup_inverse(method, L, N, L_lower, sampling, reality):
+def setup_inverse(method, L, N, L_lower, sampling, reality, mode):
     rng = np.random.default_rng()
     flmn = s2fft.utils.signal_generator.generate_flmn(rng, L, N, reality=reality)
     kernel_function = (
@@ -69,7 +72,7 @@ def setup_inverse(method, L, N, L_lower, sampling, reality):
         else s2fft.precompute_transforms.construct.wigner_kernel
     )
     kernel = kernel_function(
-        L=L, N=N, reality=reality, sampling=sampling, forward=False
+        L=L, N=N, reality=reality, sampling=sampling, forward=False, mode=mode
     )
     return {"flmn": flmn, "kernel": kernel}
 
@@ -82,8 +85,9 @@ def setup_inverse(method, L, N, L_lower, sampling, reality):
     L_lower=L_LOWER_VALUES,
     sampling=SAMPLING_VALUES,
     reality=REALITY_VALUES,
+    mode=MODE_VALUES,
 )
-def inverse(flmn, kernel, method, L, N, L_lower, sampling, reality):
+def inverse(flmn, kernel, method, L, N, L_lower, sampling, reality, mode):
     f = s2fft.precompute_transforms.wigner.inverse(
         flmn=flmn,
         L=L,

--- a/benchmarks/precompute_wigner.py
+++ b/benchmarks/precompute_wigner.py
@@ -1,12 +1,11 @@
 """Benchmarks for precompute Wigner-d transforms."""
 
 import numpy as np
-from benchmarking import benchmark, parse_args_collect_and_run_benchmarks, skip
+from benchmarking import benchmark, parse_args_collect_and_run_benchmarks
 
 import s2fft
 import s2fft.precompute_transforms
 from s2fft.base_transforms import wigner as base_wigner
-from s2fft.sampling import s2_samples as samples
 
 L_VALUES = [16, 32, 64, 128, 256]
 N_VALUES = [2]

--- a/benchmarks/precompute_wigner.py
+++ b/benchmarks/precompute_wigner.py
@@ -1,0 +1,101 @@
+"""Benchmarks for precompute Wigner-d transforms."""
+
+import numpy as np
+from benchmarking import benchmark, parse_args_collect_and_run_benchmarks, skip
+
+import s2fft
+import s2fft.precompute_transforms
+from s2fft.base_transforms import wigner as base_wigner
+from s2fft.sampling import s2_samples as samples
+
+L_VALUES = [16, 32, 64, 128, 256]
+N_VALUES = [2]
+L_LOWER_VALUES = [0]
+SAMPLING_VALUES = ["mw"]
+METHOD_VALUES = ["numpy", "jax"]
+REALITY_VALUES = [True]
+
+def setup_forward(method, L, N, L_lower, sampling, reality):
+    rng = np.random.default_rng()
+    flmn = s2fft.utils.signal_generator.generate_flmn(rng, L, N, reality=reality)
+    f = base_wigner.inverse(
+        flmn,
+        L,
+        N,
+        L_lower=L_lower,
+        sampling=sampling,
+        reality=reality,
+    )
+    kernel_function = (
+        s2fft.precompute_transforms.construct.wigner_kernel_jax
+        if method == "jax"
+        else s2fft.precompute_transforms.construct.wigner_kernel
+    )
+    kernel = kernel_function(
+        L=L, N=N, reality=reality, sampling=sampling, forward=True
+    )
+    return {"f": f, "kernel": kernel}
+
+
+@benchmark(
+    setup_forward,
+    method=METHOD_VALUES,
+    L=L_VALUES,
+    N=N_VALUES,
+    L_lower=L_LOWER_VALUES,
+    sampling=SAMPLING_VALUES,
+    reality=REALITY_VALUES,
+)
+def forward(f, kernel, method, L, N, L_lower, sampling, reality):
+    flmn = s2fft.precompute_transforms.wigner.forward(
+        f=f,
+        L=L,
+        N=N,
+        kernel=kernel,
+        sampling=sampling,
+        reality=reality,
+        method=method,
+    )
+    if method == "jax":
+        flmn.block_until_ready()
+
+
+def setup_inverse(method, L, N, L_lower, sampling, reality):
+    rng = np.random.default_rng()
+    flmn = s2fft.utils.signal_generator.generate_flmn(rng, L, N, reality=reality)
+    kernel_function = (
+        s2fft.precompute_transforms.construct.wigner_kernel_jax
+        if method == "jax"
+        else s2fft.precompute_transforms.construct.wigner_kernel
+    )
+    kernel = kernel_function(
+        L=L, N=N, reality=reality, sampling=sampling, forward=False
+    )
+    return {"flmn": flmn, "kernel": kernel}
+
+
+@benchmark(
+    setup_inverse,
+    method=METHOD_VALUES,
+    L=L_VALUES,
+    N=N_VALUES,
+    L_lower=L_LOWER_VALUES,
+    sampling=SAMPLING_VALUES,
+    reality=REALITY_VALUES,
+)
+def inverse(flmn, kernel, method, L, N, L_lower, sampling, reality):
+    f = s2fft.precompute_transforms.wigner.inverse(
+        flmn=flmn,
+        L=L,
+        N=N,
+        kernel=kernel,
+        sampling=sampling,
+        reality=reality,
+        method=method,
+    )
+    if method == "jax":
+        f.block_until_ready()
+
+
+if __name__ == "__main__":
+    results = parse_args_collect_and_run_benchmarks()

--- a/benchmarks/spherical.py
+++ b/benchmarks/spherical.py
@@ -1,4 +1,4 @@
-"""Benchmarks for spherical transforms."""
+"""Benchmarks for on-the-fly spherical transforms."""
 
 import numpy as np
 import pyssht

--- a/benchmarks/wigner.py
+++ b/benchmarks/wigner.py
@@ -16,12 +16,9 @@ L_LOWER_VALUES = [0]
 SAMPLING_VALUES = ["mw"]
 METHOD_VALUES = ["numpy", "jax"]
 REALITY_VALUES = [True]
-SPMD_VALUES = [False]
 
 
-def setup_forward(method, L, L_lower, N, sampling, reality, spmd):
-    if spmd and method != "jax":
-        skip("GPU distribution only valid for JAX.")
+def setup_forward(method, L, L_lower, N, sampling, reality):
     rng = np.random.default_rng()
     flmn = s2fft.utils.signal_generator.generate_flmn(rng, L, N, reality=reality)
     f = base_wigner.inverse(
@@ -51,27 +48,23 @@ def setup_forward(method, L, L_lower, N, sampling, reality, spmd):
     N=N_VALUES,
     sampling=SAMPLING_VALUES,
     reality=REALITY_VALUES,
-    spmd=SPMD_VALUES,
 )
-def forward(f, precomps, method, L, L_lower, N, sampling, reality, spmd):
+def forward(f, precomps, method, L, L_lower, N, sampling, reality):
     flmn = s2fft.transforms.wigner.forward(
         f=f,
         L=L,
-        L_lower=L_lower,
         N=N,
-        precomps=precomps,
         sampling=sampling,
-        reality=reality,
         method=method,
-        spmd=spmd,
+        reality=reality,
+        precomps=precomps,
+        L_lower=L_lower,
     )
     if method == "jax":
         flmn.block_until_ready()
 
 
-def setup_inverse(method, L, L_lower, N, sampling, reality, spmd):
-    if spmd and method != "jax":
-        skip("GPU distribution only valid for JAX.")
+def setup_inverse(method, L, L_lower, N, sampling, reality):
     rng = np.random.default_rng()
     flmn = s2fft.utils.signal_generator.generate_flmn(rng, L, N, reality=reality)
     generate_precomputes = (
@@ -93,19 +86,17 @@ def setup_inverse(method, L, L_lower, N, sampling, reality, spmd):
     N=N_VALUES,
     sampling=SAMPLING_VALUES,
     reality=REALITY_VALUES,
-    spmd=SPMD_VALUES,
 )
-def inverse(flmn, precomps, method, L, L_lower, N, sampling, reality, spmd):
-    f = s2fft.transforms.spherical.inverse(
-        flm=flmn,
+def inverse(flmn, precomps, method, L, L_lower, N, sampling, reality):
+    f = s2fft.transforms.wigner.inverse(
+        flmn=flmn,
         L=L,
-        L_lower=L_lower,
         N=N,
-        precomps=precomps,
         sampling=sampling,
         reality=reality,
         method=method,
-        spmd=spmd,
+        precomps=precomps,
+        L_lower=L_lower,
     )
     if method == "jax":
         f.block_until_ready()

--- a/benchmarks/wigner.py
+++ b/benchmarks/wigner.py
@@ -1,4 +1,4 @@
-"""Benchmarks for Wigner transforms."""
+"""Benchmarks for on-the-fly Wigner-d transforms."""
 
 import numpy as np
 from benchmarking import benchmark, parse_args_collect_and_run_benchmarks, skip

--- a/benchmarks/wigner.py
+++ b/benchmarks/wigner.py
@@ -1,7 +1,7 @@
 """Benchmarks for on-the-fly Wigner-d transforms."""
 
 import numpy as np
-from benchmarking import benchmark, parse_args_collect_and_run_benchmarks, skip
+from benchmarking import benchmark, parse_args_collect_and_run_benchmarks
 
 import s2fft
 from s2fft.base_transforms import wigner as base_wigner


### PR DESCRIPTION
A collection of improvements to benchmarking system made during the DiRAC NVIDIA hackathon
- Due to behaviour noted in #246 switches to always using JAX implementation for generating precomputes for spherical transforms to avoid cubic in L overhead.
- Adds benchmark modules for separate precompute versions of transforms.
- Some improvements to help text of benchmarking scripts
- Adds option to run benchmarked functions once initially without recording time to remove effect of initial JIT compilation from reported times
- Fix to issue causing only last parameter set results being recorded in JSON output
- JSON output now records additional metadata about host system such as installed package versions and information about GPUs and CPUs available, to make these more useful artefacts to store for longer term comparison.