### PR TITLE
Vectorize signal generator functions

### DIFF
--- a/s2fft/transforms/otf_recursions.py
+++ b/s2fft/transforms/otf_recursions.py
@@ -80,7 +80,14 @@ def inverse_latitudinal_step(
     half_slices = [el + mm + 1, el - mm + 1]
 
     if precomps is None:
-        precomps = generate_precomputes(L, -mm, sampling, nside, L_lower)
+        precomps = generate_precomputes(
+            L=L,
+            spin=-mm,
+            sampling=sampling,
+            nside=nside,
+            forward=False,
+            L_lower=L_lower,
+        )
     lrenorm, vsign, cpi, cp2, indices = precomps
 
     for i in range(2):

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -155,6 +155,9 @@ def inverse_numpy(
     m_start_ind = L - 1 if reality else 0
     L0 = L_lower
 
+    # Copy flm argument to avoid in-place updates being propagated back to caller
+    flm = flm.copy()
+
     # Apply harmonic normalisation
     flm[L0:] = np.einsum(
         "lm,l->lm", flm[L0:], np.sqrt((2 * np.arange(L0, L) + 1) / (4 * np.pi))

--- a/s2fft/transforms/wigner.py
+++ b/s2fft/transforms/wigner.py
@@ -156,6 +156,9 @@ def inverse_numpy(
         )
     fban = np.zeros(samples.f_shape(L, N, sampling, nside), dtype=np.complex128)
 
+    # Copy flm argument to avoid in-place updates being propagated back to caller
+    flmn = flmn.copy()
+
     flmn[:, L_lower:] = np.einsum(
         "...nlm,...l->...nlm",
         flmn[:, L_lower:],

--- a/s2fft/transforms/wigner.py
+++ b/s2fft/transforms/wigner.py
@@ -156,7 +156,7 @@ def inverse_numpy(
         )
     fban = np.zeros(samples.f_shape(L, N, sampling, nside), dtype=np.complex128)
 
-    # Copy flm argument to avoid in-place updates being propagated back to caller
+    # Copy flmn argument to avoid in-place updates being propagated back to caller
     flmn = flmn.copy()
 
     flmn[:, L_lower:] = np.einsum(

--- a/s2fft/utils/signal_generator.py
+++ b/s2fft/utils/signal_generator.py
@@ -41,8 +41,8 @@ def complex_el_and_m_indices(L: int, min_el: int) -> tuple[np.ndarray, np.ndarra
 
     ```
     el_indices, m_indices = np.array(
-        [(el, m) for el in range(min_el, L) for m in range(1, el + 1))]
-    )
+        [(el, m) for el in range(min_el, L) for m in range(1, el + 1)]
+    ).T
     ```
 
     For `L, min_el = 1024, 0`, this implementation is around 80x quicker in

--- a/s2fft/utils/signal_generator.py
+++ b/s2fft/utils/signal_generator.py
@@ -7,6 +7,66 @@ from s2fft.sampling import s2_samples as samples
 from s2fft.sampling import so3_samples as wigner_samples
 
 
+def complex_normal(
+    rng: np.random.Generator,
+    size: int | tuple[int],
+    var: float,
+) -> np.ndarray:
+    """
+    Generate array of samples from zero-mean complex normal distribution.
+
+    For `z ~ ComplexNormal(0, var)` we have that `imag(z) ~ Normal(0, var/2)` and
+    `real(z) ~ Normal(0, var/2)` where `Normal(μ, σ²)` is the (real-valued) normal
+    distribution with mean parameter `μ` and variance parameter `σ²`.
+
+    Args:
+        rng: Numpy random generator object to generate samples using.
+        size: Output shape of array to generate.
+        var: Variance of complex normal distribution to generate samples from.
+
+    Returns:
+        Complex-valued array of shape `size` contained generated samples.
+
+    """
+    return (rng.standard_normal(size) + 1j * rng.standard_normal(size)) * (
+        var / 2
+    ) ** 0.5
+
+
+def complex_el_and_m_indices(L: int, min_el: int) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Generate pairs of el, m indices for accessing complex harmonic coefficients.
+
+    Equivalent to nested list-comprehension based implementation
+
+    ```
+    el_indices, m_indices = np.array(
+        [(el, m) for el in range(min_el, L) for m in range(1, el + 1))]
+    )
+    ```
+
+    For `L, min_el = 1024, 0`, this implementation is around 80x quicker in
+    benchmarks compared to list-comprehension implementation.
+
+    Args:
+        L: Harmonic band-limit.
+        min_el: Inclusive lower-bound for el indices.
+
+    Returns:
+        Tuple `(el_indices, m_indices)` with both entries 1D integer-valued NumPy arrays
+        of same size, with values of corresponding entries corresponding to pairs of
+        el and m indices.
+
+    """
+    el_indices, m_indices = np.tril_indices(m=L, k=-1, n=L)
+    m_indices += 1
+    if min_el > 0:
+        in_range_el = el_indices >= min_el
+        el_indices = el_indices[in_range_el]
+        m_indices = m_indices[in_range_el]
+    return el_indices, m_indices
+
+
 def generate_flm(
     rng: np.random.Generator,
     L: int,
@@ -39,24 +99,24 @@ def generate_flm(
 
     """
     flm = np.zeros(samples.flm_shape(L), dtype=np.complex128)
-
     min_el = max(L_lower, abs(spin))
+    # m = 0 coefficients are always real
     flm[min_el:L, L - 1] = rng.standard_normal(L - min_el)
-    if not reality:
-        flm[min_el:L, L - 1] += 1j * rng.standard_normal(L - min_el)
-    m_indices, el_indices = np.triu_indices(n=L, k=1, m=L) + np.array([[1], [0]])
-    if min_el > 0:
-        in_range_el = el_indices >= min_el
-        m_indices = m_indices[in_range_el]
-        el_indices = el_indices[in_range_el]
+    # Construct arrays of m and el indices for entries in flm corresponding to complex-
+    # valued coefficients (m > 0)
+    el_indices, m_indices = complex_el_and_m_indices(L, min_el)
     len_indices = len(m_indices)
-    flm[el_indices, L - 1 - m_indices] = rng.standard_normal(
-        len_indices
-    ) + 1j * rng.standard_normal(len_indices)
-    flm[el_indices, L - 1 + m_indices] = (-1) ** m_indices * np.conj(
-        flm[el_indices, L - 1 - m_indices]
-    )
-
+    # Generate independent complex coefficients for positive m
+    flm[el_indices, L - 1 + m_indices] = complex_normal(rng, len_indices, var=2)
+    if reality:
+        # Real-valued signal so set complex coefficients for negative m using conjugate
+        # symmetry such that flm[el, L - 1 - m] = (-1)**m * flm[el, L - 1 + m].conj
+        flm[el_indices, L - 1 - m_indices] = (-1) ** m_indices * (
+            flm[el_indices, L - 1 + m_indices].conj()
+        )
+    else:
+        # Non-real signal so generate independent complex coefficients for negative m
+        flm[el_indices, L - 1 - m_indices] = complex_normal(rng, len_indices, var=2)
     return torch.from_numpy(flm) if using_torch else flm
 
 

--- a/s2fft/utils/signal_generator.py
+++ b/s2fft/utils/signal_generator.py
@@ -187,9 +187,12 @@ def generate_flmn(
             # conjugate symmetry relationship
             #     flmn[N - 1 - n, el, L - 1 - m] =
             #         (-1)**(m + n) * flmn[N - 1 + n, el, L - 1 + m].conj
-            flmn[N - 1 - n, el_indices, L - 1 - m_indices] = (-1) ** (m_indices + n) * (
-                flmn[N - 1 + n, el_indices, L - 1 + m_indices].conj()
-            )
+            # As (m_indices + n) can be negative use floating point value (-1.0) as
+            # base of exponentation operation to avoid Numpy
+            # 'ValueError: Integers to negative integer powers are not allowed' error
+            flmn[N - 1 - n, el_indices, L - 1 - m_indices] = (-1.0) ** (
+                m_indices + n
+            ) * flmn[N - 1 + n, el_indices, L - 1 + m_indices].conj()
         else:
             # Complex signal so generate independent complex coefficients for negative m
             flmn[N - 1 + n, el_indices, L - 1 - m_indices] = complex_normal(

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -42,6 +42,13 @@ def test_complex_el_and_m_indices(L, min_el):
     assert (m_indices == expected_m_indices).all()
 
 
+def check_flm_zeros(flm, L, min_el):
+    for el in range(L):
+        for m in range(L):
+            if el < min_el or m > el:
+                assert flm[el, L - 1 + m] == flm[el, L - 1 - m] == 0
+
+
 def check_flm_conjugate_symmetry(flm, L, min_el):
     for el in range(min_el, L):
         for m in range(el + 1):
@@ -60,6 +67,7 @@ def test_generate_flm(rng, L, L_lower, spin, reality):
     assert flm.shape == smp.s2_samples.flm_shape(L)
     assert flm.dtype == np.complex128
     assert np.isfinite(flm).all()
+    check_flm_zeros(flm, L, max(L_lower, abs(spin)))
     if reality:
         check_flm_conjugate_symmetry(flm, L, max(L_lower, abs(spin)))
         f_complex = s2fft.inverse(flm, L, spin=spin, reality=False, L_lower=L_lower)

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+
+import s2fft
+import s2fft.sampling as smp
+import s2fft.utils.signal_generator as gen
+
+L_values_to_test = [4, 7, 64]
+L_lower_to_test = [0]
+spin_to_test = [-2, 0, 1]
+reality_values_to_test = [False, True]
+
+
+@pytest.mark.parametrize("L", L_values_to_test)
+@pytest.mark.parametrize("min_el", [0, 1])
+def test_complex_el_and_m_indices(L, min_el):
+    expected_el_indices, expected_m_indices = np.array(
+        [(el, m) for el in range(min_el, L) for m in range(1, el + 1)]
+    ).T
+    el_indices, m_indices = gen.complex_el_and_m_indices(L, min_el)
+    assert (el_indices == expected_el_indices).all()
+    assert (m_indices == expected_m_indices).all()
+
+
+def check_flm_conjugate_symmetry(flm, L, min_el):
+    for el in range(min_el, L):
+        for m in range(el + 1):
+            assert flm[el, L - 1 - m] == (-1) ** m * flm[el, L - 1 + m].conj()
+
+
+@pytest.mark.parametrize("L", L_values_to_test)
+@pytest.mark.parametrize("L_lower", L_lower_to_test)
+@pytest.mark.parametrize("spin", spin_to_test)
+@pytest.mark.parametrize("reality", reality_values_to_test)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_generate_flm(rng, L, L_lower, spin, reality):
+    if reality and spin != 0:
+        pytest.skip("Reality only valid for scalar fields (spin=0).")
+    flm = gen.generate_flm(rng, L, L_lower, spin, reality)
+    assert flm.shape == smp.s2_samples.flm_shape(L)
+    assert flm.dtype == np.complex128
+    assert np.isfinite(flm).all()
+    if reality:
+        check_flm_conjugate_symmetry(flm, L, max(L_lower, abs(spin)))
+        f_complex = s2fft.inverse(flm, L, spin=spin, reality=False, L_lower=L_lower)
+        assert np.allclose(f_complex.imag, 0)
+        f_real = s2fft.inverse(flm, L, spin=spin, reality=True, L_lower=L_lower)
+        assert np.allclose(f_complex.real, f_real)

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -101,7 +101,7 @@ def check_flmn_conjugate_symmetry(flmn, L, N, L_lower):
 
 
 @pytest.mark.parametrize("L", L_values_to_test)
-@pytest.mark.parametrize("N", [1, 2])
+@pytest.mark.parametrize("N", [1, 2, 3])
 @pytest.mark.parametrize("L_lower", L_lower_to_test)
 @pytest.mark.parametrize("reality", reality_values_to_test)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/test_spherical_precompute.py
+++ b/tests/test_spherical_precompute.py
@@ -298,7 +298,7 @@ def test_transform_inverse_high_spin(
     kernel = c.spin_spherical_kernel(L, spin, reality, sampling, forward=False)
 
     f = inverse(flm, L, spin, kernel, sampling, reality, "numpy")
-    tol = 1e-8 if sampling.lower() in ["dh", "gl"] else 1e-12
+    tol = 1e-8 if sampling.lower() in ["dh", "gl"] else 1e-11
     np.testing.assert_allclose(f, f_check, atol=tol, rtol=tol)
 
 


### PR DESCRIPTION
When running some benchmarks with large `L` I noticed that the signal generation functions in `s2fft.utils.signal_generator` become very slow for large `L` due to the nested for loops.

This switches to using a vectorized implementation. ~~Currently implemented for `generate_flm` only.~~

EDIT: Now implemented for both `generate_flm` and `generate_flmn`.