### PR TITLE
Add Actions workflow file for collecting repository statistics

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,19 @@
+name: Record GitHub repository statistics
+
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  collect-stats:
+    name: github-repo-stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        # Use latest release.
+        uses: jgehrcke/github-repo-stats@306db38ad131cab2aa5f2cd3062bf6f8aa78c1aa
+        with:
+          ghtoken: ${{ secrets.ghrs_github_api_token }}


### PR DESCRIPTION
Should resolve #219 

Adds Actions workflow file using [`github-repo-stats`](https://github.com/jgehrcke/github-repo-stats) Action to record GitHub repository statistics in to a branch `github-repo-stats` on a daily schedule.

Requires creating a new access token with permissions to push commits and access repository statistics on this repository. The [tutorial for action](https://github.com/jgehrcke/github-repo-stats/wiki/Tutorial#step-1-create-personal-access-token-and-store-it-as-repository-secret) recommends using a classic personal access token with no expiry, however if possible would be good to avoid using such a token as it will provide (write / admin) access to all repositories under an account. Ideally we should instead use [a fine-grained personal acccess token](https://github.com/settings/personal-access-tokens/new) with access to just this repository and with only relevant needed permissions set. This will need to be set up by someone with admin permissions on `astroinformatics` organization.