### PR TITLE
Fix failing `test_transform_forward_healpix_iter` test

### DIFF
--- a/tests/test_spherical_base.py
+++ b/tests/test_spherical_base.py
@@ -14,7 +14,6 @@ L_to_nside_ratio = [2, 3]
 sampling_to_test = ["mw", "mwss", "dh", "gl"]
 method_to_test = ["direct", "sov", "sov_fft", "sov_fft_vectorized"]
 reality_to_test = [False, True]
-iter_to_test = [7, 10]
 
 
 @pytest.mark.parametrize("L", L_to_test)
@@ -133,14 +132,12 @@ def test_transform_forward_healpix(
 
 
 @pytest.mark.parametrize("nside", nside_to_test)
-@pytest.mark.parametrize("reality", reality_to_test)
-@pytest.mark.parametrize("iter", iter_to_test)
-def test_transform_forward_healpix_iter(
-    flm_generator, nside: int, reality: bool, iter: int
-):
+@pytest.mark.parametrize("iter", [8, 10])
+def test_transform_forward_healpix_iter(flm_generator, nside: int, iter: int):
     sampling = "healpix"
     L = 2 * nside
-    flm = flm_generator(L=L, reality=True)
+    reality = True
+    flm = flm_generator(L=L, reality=reality)
     f = spherical.inverse(flm, L, sampling=sampling, nside=nside, reality=reality)
     flm_direct = spherical.forward(
         f,


### PR DESCRIPTION
Unfortunately recent merges seemed to have caused `test_transform_forward_healpix_iter` test in `tests/test_spherical_base.py` to [begin failing](https://github.com/astro-informatics/s2fft/actions/runs/12394302956/job/34601992042) for some parameter combinations (specifically when `n_iter = 7`). Looking at the failures I think these are spurious as the round-trip errors reported are still very small, but just not within the specified error tolerance, and they consistently are within the tolerance for the larger `n_iter = 10` tested. I think this just an artefact of #252 having changed the specific `flm` values that will be generated (as the vectorized function draws variates in a different order) and I having chose the minimum number of iterations to test to be too small for the tolerance being checked. Slightly increasing the number of iterations to `n_iter = 8` fixes. I also noticed that we were testing with `reality` parametrized to both `True` and `False`, but as I think the `healpy` functions assume the signal is always real, I've reduced to just fixing `reality = True` here.