### PR TITLE
Record numerical error in benchmarks and cost + memory estimates for JAX functions

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,7 +12,6 @@ If the [`py-cpuinfo` package](https://pypi.org/project/py-cpuinfo/)
 is installed additional information about CPU of system benchmarks are run on will be
 recorded in JSON output.
 
-
 ## Description
 
 The benchmark scripts are as follows:
@@ -40,7 +39,7 @@ display the usage message:
 ```
 usage: spherical.py [-h] [-number-runs NUMBER_RUNS] [-repeats REPEATS]
                     [-parameter-overrides [PARAMETER_OVERRIDES ...]] [-output-file OUTPUT_FILE]
-                    [--run-once-and-discard]
+                    [-benchmarks BENCHMARKS [BENCHMARKS ...]]
 
 Benchmarks for on-the-fly spherical transforms.
 
@@ -55,9 +54,8 @@ options:
                         parameters. (default: None)
   -output-file OUTPUT_FILE
                         File path to write JSON formatted results to. (default: None)
-  --run-once-and-discard
-                        Run benchmark function once first without recording time to ignore the effect of any initial
-                        one-off costs such as just-in-time compilation. (default: False)
+  -benchmarks BENCHMARKS [BENCHMARKS ...]
+                        Names of benchmark functions to run. All benchmarks are run if omitted. (default: None)
 ```
 
 For example to run the spherical transform benchmarks using only the JAX implementations,
@@ -65,7 +63,7 @@ running on a CPU (in double-precision) for `L` values 64, 128, 256, 512 and 1024
 would run from the root of the repository:
 
 ```sh
-JAX_PLATFORM_NAME=cpu JAX_ENABLE_X64=1 python benchmarks/spherical.py --run-once-and-discard -p L 64 128 256 512 1024 -p method jax
+JAX_PLATFORM_NAME=cpu JAX_ENABLE_X64=1 python benchmarks/spherical.py -p L 64 128 256 512 1024 -p method jax
 ```
 
 Note the usage of environment variables `JAX_PLATFORM_NAME` and `JAX_ENABLE_X64` to 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,13 +1,10 @@
 # Benchmarks for `s2fft`
 
-Scripts for benchmarking `s2fft` with `timeit` (and optionally `memory_profiler`).
+Scripts for benchmarking `s2fft` transforms.
 
 Measures time to compute transforms for grids of parameters settings, optionally 
 outputting the results to a JSON file to allow comparing performance over versions
-and/or systems. 
-If the [`memory_profiler` package](https://github.com/pythonprofilers/memory_profiler) 
-is installed an estimate of the peak (main) memory usage of the benchmarked functions
-will also be recorded.
+and/or systems.
 If the [`py-cpuinfo` package](https://pypi.org/project/py-cpuinfo/) 
 is installed additional information about CPU of system benchmarks are run on will be
 recorded in JSON output.

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -372,10 +372,12 @@ def _compile_jax_benchmark_and_analyse(
     """Compile a JAX benchmark function and extract cost estimates if available."""
     compiled_benchmark_function = jax.jit(benchmark_function).lower().compile()
     cost_analysis = compiled_benchmark_function.cost_analysis()
-    if cost_analysis is not None and isinstance(cost_analysis, list):
+    if cost_analysis is not None:
+        if isinstance(cost_analysis, list):
+            cost_analysis = cost_analysis[0]
         results_entry["cost_analysis"] = {
-            "flops": cost_analysis[0].get("flops"),
-            "bytes_accessed": cost_analysis[0].get("bytes accessed"),
+            "flops": cost_analysis.get("flops"),
+            "bytes_accessed": cost_analysis.get("bytes accessed"),
         }
     memory_analysis = compiled_benchmark_function.memory_analysis()
     if memory_analysis is not None:

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -190,7 +190,7 @@ def benchmark(
             dictionary of values to pass to the benchmark as keyword arguments,
             corresponding to any precomputed values, the second entry optionally a
             reference value specifying the expected 'true' numerical output of the
-            behchmarked function to allow computing numerical error, or `None` if there
+            benchmarked function to allow computing numerical error, or `None` if there
             is no relevant reference value and third entry a boolean flag indicating
             whether to use JAX's just-in-time compilation transform to benchmark
             function.

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -451,6 +451,9 @@ def run_benchmarks(
                     results_entry["max_abs_error"] = abs(
                         reference_output - output
                     ).max()
+                    results_entry["mean_abs_error"] = abs(
+                        reference_output - output
+                    ).mean()
                 run_times = [
                     time / number_runs
                     for time in timeit.repeat(

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -448,12 +448,12 @@ def run_benchmarks(
                 results_entry["traced_memory_final_in_bytes"] = current_size
                 results_entry["traced_memory_peak_in_bytes"] = peak_size
                 if reference_output is not None and output is not None:
-                    results_entry["max_abs_error"] = abs(
-                        reference_output - output
-                    ).max()
-                    results_entry["mean_abs_error"] = abs(
-                        reference_output - output
-                    ).mean()
+                    results_entry["max_abs_error"] = float(
+                        abs(reference_output - output).max()
+                    )
+                    results_entry["mean_abs_error"] = float(
+                        abs(reference_output - output).mean()
+                    )
                 run_times = [
                     time / number_runs
                     for time in timeit.repeat(

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -317,7 +317,9 @@ def run_benchmarks(
             print(benchmark.__name__)
         parameters = benchmark.parameters.copy()
         if parameter_overrides is not None:
-            parameters.update(parameter_overrides)
+            for parameter_name, parameter_values in parameter_overrides.items():
+                if parameter_name in parameters:
+                    parameters[parameter_name] = parameter_values
         for parameter_set in _dict_product(parameters):
             try:
                 precomputes, reference_output = benchmark.setup(**parameter_set)

--- a/benchmarks/benchmarking.py
+++ b/benchmarks/benchmarking.py
@@ -238,7 +238,7 @@ def _format_results_entry(results_entry: dict) -> str:
         )
         + (
             f", max(abs(error)): {results_entry['max_abs_error']:>#7.2g}"
-            if "error" in results_entry
+            if "max_abs_error" in results_entry
             else ""
         )
         + (

--- a/benchmarks/plotting.py
+++ b/benchmarks/plotting.py
@@ -33,10 +33,10 @@ def _plot_scaling_guide(
     order: int,
 ) -> None:
     n = np.argsort(parameter_values)[len(parameter_values) // 2]
-    coefficient = measurement_values[n] / parameter_values[n] ** order
+    coefficient = measurement_values[n] / float(parameter_values[n]) ** order
     ax.plot(
         parameter_values,
-        coefficient * parameter_values**order,
+        coefficient * parameter_values.astype(float) ** order,
         "k:",
         label=f"$\\mathcal{{O}}({parameter_symbol}^{order})$",
     )

--- a/benchmarks/plotting.py
+++ b/benchmarks/plotting.py
@@ -1,0 +1,209 @@
+"""Utilities for plotting benchmark results."""
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def _set_axis_properties(
+    ax: plt.Axes,
+    parameter_values: np.ndarray,
+    parameter_label: str,
+    measurement_label: str,
+) -> None:
+    ax.set(
+        xlabel=parameter_label,
+        ylabel=measurement_label,
+        xscale="log",
+        yscale="log",
+        xticks=parameter_values,
+        xticklabels=parameter_values,
+    )
+    ax.minorticks_off()
+
+
+def _plot_scaling_guide(
+    ax: plt.Axes,
+    parameter_symbol: str,
+    parameter_values: np.ndarray,
+    measurement_values: np.ndarray,
+    order: int,
+) -> None:
+    n = np.argsort(parameter_values)[len(parameter_values) // 2]
+    coefficient = measurement_values[n] / parameter_values[n] ** order
+    ax.plot(
+        parameter_values,
+        coefficient * parameter_values**order,
+        "k:",
+        label=f"$\\mathcal{{O}}({parameter_symbol}^{order})$",
+    )
+
+
+def plot_times(
+    ax: plt.Axes, parameter_symbol: str, parameter_values: np.ndarray, results: dict
+) -> None:
+    min_times = np.array([min(r["run_times_in_seconds"]) for r in results])
+    mid_times = np.array([np.median(r["run_times_in_seconds"]) for r in results])
+    max_times = np.array([max(r["run_times_in_seconds"]) for r in results])
+    ax.plot(parameter_values, mid_times, label="Measured")
+    ax.fill_between(parameter_values, min_times, max_times, alpha=0.5)
+    _plot_scaling_guide(ax, parameter_symbol, parameter_values, mid_times, 3)
+    ax.legend()
+
+
+def plot_flops(
+    ax: plt.Axes, parameter_symbol: str, parameter_values: np.ndarray, results: dict
+) -> None:
+    flops = np.array([r["cost_analysis"]["flops"] for r in results])
+    ax.plot(parameter_values, flops, label="Measured")
+    _plot_scaling_guide(ax, parameter_symbol, parameter_values, flops, 2)
+    ax.legend()
+
+
+def plot_error(
+    ax: plt.Axes, parameter_symbol: str, parameter_values: np.ndarray, results: dict
+) -> None:
+    max_abs_errors = np.array([r["max_abs_error"] for r in results])
+    mean_abs_errors = np.array([r["mean_abs_error"] for r in results])
+    ax.plot(parameter_values, max_abs_errors, label="max(abs(error))")
+    ax.plot(parameter_values, mean_abs_errors, label="mean(abs(error))")
+    _plot_scaling_guide(
+        ax,
+        parameter_symbol,
+        parameter_values,
+        (max_abs_errors + mean_abs_errors) / 2,
+        2,
+    )
+    ax.legend()
+
+
+def plot_memory(
+    ax: plt.Axes, parameter_symbol: str, parameter_values: np.ndarray, results: dict
+) -> None:
+    bytes_accessed = np.array([r["cost_analysis"]["bytes_accessed"] for r in results])
+    temp_size_in_bytes = np.array(
+        [r["memory_analysis"]["temp_size_in_bytes"] for r in results]
+    )
+    output_size_in_bytes = np.array(
+        [r["memory_analysis"]["output_size_in_bytes"] for r in results]
+    )
+    generated_code_size_in_bytes = np.array(
+        [r["memory_analysis"]["generated_code_size_in_bytes"] for r in results]
+    )
+    ax.plot(parameter_values, bytes_accessed, label="Accesses")
+    ax.plot(parameter_values, temp_size_in_bytes, label="Temporary allocations")
+    ax.plot(parameter_values, output_size_in_bytes, label="Output size")
+    ax.plot(parameter_values, generated_code_size_in_bytes, label="Generated code size")
+    _plot_scaling_guide(
+        ax,
+        parameter_symbol,
+        parameter_values,
+        (bytes_accessed + output_size_in_bytes) / 2,
+        2,
+    )
+    ax.legend()
+
+
+_measurement_plot_functions_and_labels = {
+    "times": (plot_times, "Run time / s"),
+    "flops": (plot_flops, "Floating point operations"),
+    "memory": (plot_memory, "Memory / B"),
+    "error": (plot_error, "Numerical error"),
+}
+
+
+def plot_results_against_bandlimit(
+    benchmark_results_path: str | Path,
+    functions: tuple[str] = ("forward", "inverse"),
+    measurements: tuple[str] = ("times", "flops", "memory", "error"),
+    axis_size: float = 3.0,
+    fig_dpi: int = 100,
+) -> tuple[plt.Figure, plt.Axes]:
+    benchmark_results_path = Path(benchmark_results_path)
+    with benchmark_results_path.open("r") as f:
+        benchmark_results = json.load(f)
+    n_functions = len(functions)
+    n_measurements = len(measurements)
+    fig, axes = plt.subplots(
+        n_functions,
+        n_measurements,
+        figsize=(axis_size * n_measurements, axis_size * n_functions),
+        dpi=fig_dpi,
+        squeeze=False,
+    )
+    for axes_row, function in zip(axes, functions):
+        results = benchmark_results["results"][function]
+        l_values = np.array([r["parameters"]["L"] for r in results])
+        for ax, measurement in zip(axes_row, measurements):
+            plot_function, label = _measurement_plot_functions_and_labels[measurement]
+            try:
+                plot_function(ax, "L", l_values, results)
+                ax.set(title=function)
+            except KeyError:
+                ax.axis("off")
+            _set_axis_properties(ax, l_values, "Bandlimit $L$", label)
+    return fig, ax
+
+
+def _parse_cli_arguments() -> argparse.Namespace:
+    """Parse rguments passed for plotting command line interface"""
+    parser = argparse.ArgumentParser(
+        description="Generate plot from benchmark results file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-results-path",
+        type=Path,
+        help="Path to JSON file containing benchmark results to plot.",
+    )
+    parser.add_argument(
+        "-output-path",
+        type=Path,
+        help="Path to write figure to.",
+    )
+    parser.add_argument(
+        "-functions",
+        nargs="+",
+        help="Names of functions to plot. forward and inverse are plotted if omitted.",
+    )
+    parser.add_argument(
+        "-measurements",
+        nargs="+",
+        help="Names of measurements to plot. All functions are plotted if omitted.",
+    )
+    parser.add_argument(
+        "-axis-size", type=float, default=5.0, help="Size of each plot axis in inches."
+    )
+    parser.add_argument(
+        "-dpi", type=int, default=100, help="Figure resolution in dots per inch."
+    )
+    parser.add_argument(
+        "-title", type=str, help="Title for figure. No title added if omitted."
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_cli_arguments()
+    functions = (
+        ("forward", "inverse") if args.functions is None else tuple(args.functions)
+    )
+    measurements = (
+        ("times", "flops", "memory", "error")
+        if args.measurements is None
+        else tuple(args.measurements)
+    )
+    fig, _ = plot_results_against_bandlimit(
+        args.results_path,
+        functions=functions,
+        measurements=measurements,
+        axis_size=args.axis_size,
+        fig_dpi=args.dpi,
+    )
+    if args.title is not None:
+        fig.suptitle(args.title)
+    fig.tight_layout()
+    fig.savefig(args.output_path)

--- a/benchmarks/precompute_spherical.py
+++ b/benchmarks/precompute_spherical.py
@@ -1,7 +1,12 @@
 """Benchmarks for precompute spherical transforms."""
 
 import numpy as np
-from benchmarking import benchmark, parse_args_collect_and_run_benchmarks, skip
+from benchmarking import (
+    BenchmarkSetup,
+    benchmark,
+    parse_args_collect_and_run_benchmarks,
+    skip,
+)
 
 import s2fft
 import s2fft.precompute_transforms
@@ -39,7 +44,7 @@ def setup_forward(method, L, sampling, spin, reality, recursion):
         forward=True,
         recursion=recursion,
     )
-    return {"f": f, "kernel": kernel}, flm
+    return BenchmarkSetup({"f": f, "kernel": kernel}, flm, "jax" in method)
 
 
 @benchmark(
@@ -52,7 +57,7 @@ def setup_forward(method, L, sampling, spin, reality, recursion):
     recursion=RECURSION_VALUES,
 )
 def forward(f, kernel, method, L, sampling, spin, reality, recursion):
-    flm = s2fft.precompute_transforms.spherical.forward(
+    return s2fft.precompute_transforms.spherical.forward(
         f=f,
         L=L,
         spin=spin,
@@ -61,9 +66,6 @@ def forward(f, kernel, method, L, sampling, spin, reality, recursion):
         reality=reality,
         method=method,
     )
-    if method == "jax":
-        flm.block_until_ready()
-    return flm
 
 
 def setup_inverse(method, L, sampling, spin, reality, recursion):
@@ -84,7 +86,7 @@ def setup_inverse(method, L, sampling, spin, reality, recursion):
         forward=False,
         recursion=recursion,
     )
-    return {"flm": flm, "kernel": kernel}, None
+    return BenchmarkSetup({"flm": flm, "kernel": kernel}, None, "jax" in method)
 
 
 @benchmark(
@@ -97,7 +99,7 @@ def setup_inverse(method, L, sampling, spin, reality, recursion):
     recursion=RECURSION_VALUES,
 )
 def inverse(flm, kernel, method, L, sampling, spin, reality, recursion):
-    f = s2fft.precompute_transforms.spherical.inverse(
+    return s2fft.precompute_transforms.spherical.inverse(
         flm=flm,
         L=L,
         spin=spin,
@@ -106,9 +108,6 @@ def inverse(flm, kernel, method, L, sampling, spin, reality, recursion):
         reality=reality,
         method=method,
     )
-    if method == "jax":
-        f.block_until_ready()
-    return f
 
 
 if __name__ == "__main__":

--- a/benchmarks/precompute_spherical.py
+++ b/benchmarks/precompute_spherical.py
@@ -1,12 +1,10 @@
 """Benchmarks for precompute spherical transforms."""
 
 import numpy as np
-import pyssht
 from benchmarking import benchmark, parse_args_collect_and_run_benchmarks, skip
 
 import s2fft
 import s2fft.precompute_transforms
-from s2fft.sampling import s2_samples as samples
 
 L_VALUES = [8, 16, 32, 64, 128, 256]
 SPIN_VALUES = [0]
@@ -21,12 +19,12 @@ def setup_forward(method, L, sampling, spin, reality, recursion):
         skip("Reality only valid for scalar fields (spin=0).")
     rng = np.random.default_rng()
     flm = s2fft.utils.signal_generator.generate_flm(rng, L, spin=spin, reality=reality)
-    f = pyssht.inverse(
-        samples.flm_2d_to_1d(flm, L),
-        L,
-        Method=sampling.upper(),
-        Spin=spin,
-        Reality=reality,
+    f = s2fft.transforms.spherical.inverse(
+        flm,
+        L=L,
+        spin=spin,
+        sampling=sampling,
+        reality=reality,
     )
     kernel_function = (
         s2fft.precompute_transforms.construct.spin_spherical_kernel_jax

--- a/benchmarks/precompute_spherical.py
+++ b/benchmarks/precompute_spherical.py
@@ -41,7 +41,7 @@ def setup_forward(method, L, sampling, spin, reality, recursion):
         forward=True,
         recursion=recursion,
     )
-    return {"f": f, "kernel": kernel}
+    return {"f": f, "kernel": kernel}, flm
 
 
 @benchmark(
@@ -65,6 +65,7 @@ def forward(f, kernel, method, L, sampling, spin, reality, recursion):
     )
     if method == "jax":
         flm.block_until_ready()
+    return flm
 
 
 def setup_inverse(method, L, sampling, spin, reality, recursion):
@@ -85,7 +86,7 @@ def setup_inverse(method, L, sampling, spin, reality, recursion):
         forward=False,
         recursion=recursion,
     )
-    return {"flm": flm, "kernel": kernel}
+    return {"flm": flm, "kernel": kernel}, None
 
 
 @benchmark(
@@ -109,6 +110,7 @@ def inverse(flm, kernel, method, L, sampling, spin, reality, recursion):
     )
     if method == "jax":
         f.block_until_ready()
+    return f
 
 
 if __name__ == "__main__":

--- a/benchmarks/precompute_wigner.py
+++ b/benchmarks/precompute_wigner.py
@@ -35,7 +35,7 @@ def setup_forward(method, L, N, L_lower, sampling, reality, mode):
     kernel = kernel_function(
         L=L, N=N, reality=reality, sampling=sampling, forward=True, mode=mode
     )
-    return {"f": f, "kernel": kernel}
+    return {"f": f, "kernel": kernel}, flmn
 
 
 @benchmark(
@@ -60,6 +60,7 @@ def forward(f, kernel, method, L, N, L_lower, sampling, reality, mode):
     )
     if method == "jax":
         flmn.block_until_ready()
+    return flmn
 
 
 def setup_inverse(method, L, N, L_lower, sampling, reality, mode):
@@ -73,7 +74,7 @@ def setup_inverse(method, L, N, L_lower, sampling, reality, mode):
     kernel = kernel_function(
         L=L, N=N, reality=reality, sampling=sampling, forward=False, mode=mode
     )
-    return {"flmn": flmn, "kernel": kernel}
+    return {"flmn": flmn, "kernel": kernel}, None
 
 
 @benchmark(
@@ -98,6 +99,7 @@ def inverse(flmn, kernel, method, L, N, L_lower, sampling, reality, mode):
     )
     if method == "jax":
         f.block_until_ready()
+    return f
 
 
 if __name__ == "__main__":

--- a/benchmarks/precompute_wigner.py
+++ b/benchmarks/precompute_wigner.py
@@ -1,7 +1,11 @@
 """Benchmarks for precompute Wigner-d transforms."""
 
 import numpy as np
-from benchmarking import benchmark, parse_args_collect_and_run_benchmarks
+from benchmarking import (
+    BenchmarkSetup,
+    benchmark,
+    parse_args_collect_and_run_benchmarks,
+)
 
 import s2fft
 import s2fft.precompute_transforms
@@ -29,13 +33,13 @@ def setup_forward(method, L, N, L_lower, sampling, reality, mode):
     )
     kernel_function = (
         s2fft.precompute_transforms.construct.wigner_kernel_jax
-        if method == "jax"
+        if "jax" in method
         else s2fft.precompute_transforms.construct.wigner_kernel
     )
     kernel = kernel_function(
         L=L, N=N, reality=reality, sampling=sampling, forward=True, mode=mode
     )
-    return {"f": f, "kernel": kernel}, flmn
+    return BenchmarkSetup({"f": f, "kernel": kernel}, flmn, "jax" in method)
 
 
 @benchmark(
@@ -49,7 +53,7 @@ def setup_forward(method, L, N, L_lower, sampling, reality, mode):
     mode=MODE_VALUES,
 )
 def forward(f, kernel, method, L, N, L_lower, sampling, reality, mode):
-    flmn = s2fft.precompute_transforms.wigner.forward(
+    return s2fft.precompute_transforms.wigner.forward(
         f=f,
         L=L,
         N=N,
@@ -58,9 +62,6 @@ def forward(f, kernel, method, L, N, L_lower, sampling, reality, mode):
         reality=reality,
         method=method,
     )
-    if method == "jax":
-        flmn.block_until_ready()
-    return flmn
 
 
 def setup_inverse(method, L, N, L_lower, sampling, reality, mode):
@@ -74,7 +75,7 @@ def setup_inverse(method, L, N, L_lower, sampling, reality, mode):
     kernel = kernel_function(
         L=L, N=N, reality=reality, sampling=sampling, forward=False, mode=mode
     )
-    return {"flmn": flmn, "kernel": kernel}, None
+    return BenchmarkSetup({"flmn": flmn, "kernel": kernel}, None, "jax" in method)
 
 
 @benchmark(
@@ -88,7 +89,7 @@ def setup_inverse(method, L, N, L_lower, sampling, reality, mode):
     mode=MODE_VALUES,
 )
 def inverse(flmn, kernel, method, L, N, L_lower, sampling, reality, mode):
-    f = s2fft.precompute_transforms.wigner.inverse(
+    return s2fft.precompute_transforms.wigner.inverse(
         flmn=flmn,
         L=L,
         N=N,
@@ -97,9 +98,6 @@ def inverse(flmn, kernel, method, L, N, L_lower, sampling, reality, mode):
         reality=reality,
         method=method,
     )
-    if method == "jax":
-        f.block_until_ready()
-    return f
 
 
 if __name__ == "__main__":

--- a/benchmarks/spherical.py
+++ b/benchmarks/spherical.py
@@ -28,12 +28,14 @@ def setup_forward(method, L, L_lower, sampling, spin, reality, spmd):
         skip("GPU distribution only valid for JAX.")
     rng = np.random.default_rng()
     flm = s2fft.utils.signal_generator.generate_flm(rng, L, spin=spin, reality=reality)
-    f = pyssht.inverse(
-        samples.flm_2d_to_1d(flm, L),
-        L,
-        Method=sampling.upper(),
-        Spin=spin,
-        Reality=reality,
+    f = s2fft.transforms.spherical.inverse(
+        flm,
+        L=L,
+        spin=spin,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
     )
     precomps = generate_precomputes_jax(
         L, spin, sampling, forward=True, L_lower=L_lower

--- a/benchmarks/spherical.py
+++ b/benchmarks/spherical.py
@@ -42,6 +42,7 @@ def setup_forward(
         spin=spin,
         nside=nside,
         sampling=sampling,
+        method=method,
         reality=reality,
         spmd=spmd,
         L_lower=L_lower,

--- a/benchmarks/spherical.py
+++ b/benchmarks/spherical.py
@@ -1,8 +1,12 @@
 """Benchmarks for on-the-fly spherical transforms."""
 
-import jax
 import numpy as np
-from benchmarking import benchmark, parse_args_collect_and_run_benchmarks, skip
+from benchmarking import (
+    BenchmarkSetup,
+    benchmark,
+    parse_args_collect_and_run_benchmarks,
+    skip,
+)
 
 import s2fft
 from s2fft.recursions.price_mcewen import generate_precomputes_jax
@@ -52,7 +56,7 @@ def setup_forward(
     )
     if method == "numpy":
         precomps = _jax_arrays_to_numpy(precomps)
-    return {"f": f, "precomps": precomps}, flm
+    return BenchmarkSetup({"f": f, "precomps": precomps}, flm, "jax" in method)
 
 
 @benchmark(
@@ -80,7 +84,7 @@ def forward(
     spmd,
     n_iter,
 ):
-    flm = s2fft.transforms.spherical.forward(
+    return s2fft.transforms.spherical.forward(
         f=f,
         L=L,
         L_lower=L_lower,
@@ -93,7 +97,6 @@ def forward(
         spmd=spmd,
         iter=n_iter,
     )
-    return flm.block_until_ready() if isinstance(flm, jax.Array) else flm
 
 
 def setup_inverse(method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd):
@@ -113,7 +116,7 @@ def setup_inverse(method, L, L_lower, sampling, spin, L_to_nside_ratio, reality,
     )
     if method == "numpy":
         precomps = _jax_arrays_to_numpy(precomps)
-    return {"flm": flm, "precomps": precomps}, None
+    return BenchmarkSetup({"flm": flm, "precomps": precomps}, None, "jax" in method)
 
 
 @benchmark(
@@ -130,7 +133,7 @@ def setup_inverse(method, L, L_lower, sampling, spin, L_to_nside_ratio, reality,
 def inverse(
     flm, precomps, method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd
 ):
-    f = s2fft.transforms.spherical.inverse(
+    return s2fft.transforms.spherical.inverse(
         flm=flm,
         L=L,
         L_lower=L_lower,
@@ -142,7 +145,6 @@ def inverse(
         method=method,
         spmd=spmd,
     )
-    return f.block_until_ready() if isinstance(f, jax.Array) else f
 
 
 if __name__ == "__main__":

--- a/benchmarks/spherical.py
+++ b/benchmarks/spherical.py
@@ -16,6 +16,7 @@ SAMPLING_VALUES = ["mw"]
 METHOD_VALUES = ["numpy", "jax"]
 REALITY_VALUES = [True]
 SPMD_VALUES = [False]
+N_ITER_VALUES = [None]
 
 
 def _jax_arrays_to_numpy(precomps):
@@ -26,7 +27,9 @@ def _get_nside(sampling, L, L_to_nside_ratio):
     return None if sampling != "healpix" else L // L_to_nside_ratio
 
 
-def setup_forward(method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd):
+def setup_forward(
+    method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd, n_iter
+):
     if reality and spin != 0:
         skip("Reality only valid for scalar fields (spin=0).")
     if spmd and method != "jax":
@@ -62,9 +65,20 @@ def setup_forward(method, L, L_lower, sampling, spin, L_to_nside_ratio, reality,
     L_to_nside_ratio=L_TO_NSIDE_RATIO_VALUES,
     reality=REALITY_VALUES,
     spmd=SPMD_VALUES,
+    n_iter=N_ITER_VALUES,
 )
 def forward(
-    f, precomps, method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd
+    f,
+    precomps,
+    method,
+    L,
+    L_lower,
+    sampling,
+    spin,
+    L_to_nside_ratio,
+    reality,
+    spmd,
+    n_iter,
 ):
     if method == "pyssht":
         flm = pyssht.forward(f, L, spin, sampling.upper())
@@ -80,6 +94,7 @@ def forward(
             reality=reality,
             method=method,
             spmd=spmd,
+            iter=n_iter,
         )
     if method == "jax":
         flm.block_until_ready()

--- a/benchmarks/spherical.py
+++ b/benchmarks/spherical.py
@@ -40,7 +40,7 @@ def setup_forward(method, L, L_lower, sampling, spin, reality, spmd):
     )
     if method == "numpy":
         precomps = _jax_arrays_to_numpy(precomps)
-    return {"f": f, "precomps": precomps}
+    return {"f": f, "precomps": precomps}, flm
 
 
 @benchmark(
@@ -70,6 +70,7 @@ def forward(f, precomps, method, L, L_lower, sampling, spin, reality, spmd):
         )
     if method == "jax":
         flm.block_until_ready()
+    return flm
 
 
 def setup_inverse(method, L, L_lower, sampling, spin, reality, spmd):
@@ -84,7 +85,7 @@ def setup_inverse(method, L, L_lower, sampling, spin, reality, spmd):
     )
     if method == "numpy":
         precomps = _jax_arrays_to_numpy(precomps)
-    return {"flm": flm, "precomps": precomps}
+    return {"flm": flm, "precomps": precomps}, None
 
 
 @benchmark(
@@ -114,6 +115,7 @@ def inverse(flm, precomps, method, L, L_lower, sampling, spin, reality, spmd):
         )
     if method == "jax":
         f.block_until_ready()
+    return f
 
 
 if __name__ == "__main__":

--- a/benchmarks/spherical.py
+++ b/benchmarks/spherical.py
@@ -11,6 +11,7 @@ from s2fft.sampling import s2_samples as samples
 L_VALUES = [8, 16, 32, 64, 128, 256]
 L_LOWER_VALUES = [0]
 SPIN_VALUES = [0]
+L_TO_NSIDE_RATIO_VALUES = [2]
 SAMPLING_VALUES = ["mw"]
 METHOD_VALUES = ["numpy", "jax"]
 REALITY_VALUES = [True]
@@ -21,24 +22,30 @@ def _jax_arrays_to_numpy(precomps):
     return [np.asarray(p) for p in precomps]
 
 
-def setup_forward(method, L, L_lower, sampling, spin, reality, spmd):
+def _get_nside(sampling, L, L_to_nside_ratio):
+    return None if sampling != "healpix" else L // L_to_nside_ratio
+
+
+def setup_forward(method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd):
     if reality and spin != 0:
         skip("Reality only valid for scalar fields (spin=0).")
     if spmd and method != "jax":
         skip("GPU distribution only valid for JAX.")
     rng = np.random.default_rng()
     flm = s2fft.utils.signal_generator.generate_flm(rng, L, spin=spin, reality=reality)
+    nside = _get_nside(sampling, L, L_to_nside_ratio)
     f = s2fft.transforms.spherical.inverse(
         flm,
         L=L,
         spin=spin,
+        nside=nside,
         sampling=sampling,
         reality=reality,
         spmd=spmd,
         L_lower=L_lower,
     )
     precomps = generate_precomputes_jax(
-        L, spin, sampling, forward=True, L_lower=L_lower
+        L, spin, sampling, nside=nside, forward=True, L_lower=L_lower
     )
     if method == "numpy":
         precomps = _jax_arrays_to_numpy(precomps)
@@ -52,10 +59,13 @@ def setup_forward(method, L, L_lower, sampling, spin, reality, spmd):
     L_lower=L_LOWER_VALUES,
     sampling=SAMPLING_VALUES,
     spin=SPIN_VALUES,
+    L_to_nside_ratio=L_TO_NSIDE_RATIO_VALUES,
     reality=REALITY_VALUES,
     spmd=SPMD_VALUES,
 )
-def forward(f, precomps, method, L, L_lower, sampling, spin, reality, spmd):
+def forward(
+    f, precomps, method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd
+):
     if method == "pyssht":
         flm = pyssht.forward(f, L, spin, sampling.upper())
     else:
@@ -65,6 +75,7 @@ def forward(f, precomps, method, L, L_lower, sampling, spin, reality, spmd):
             L_lower=L_lower,
             precomps=precomps,
             spin=spin,
+            nside=_get_nside(sampling, L, L_to_nside_ratio),
             sampling=sampling,
             reality=reality,
             method=method,
@@ -75,7 +86,7 @@ def forward(f, precomps, method, L, L_lower, sampling, spin, reality, spmd):
     return flm
 
 
-def setup_inverse(method, L, L_lower, sampling, spin, reality, spmd):
+def setup_inverse(method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd):
     if reality and spin != 0:
         skip("Reality only valid for scalar fields (spin=0).")
     if spmd and method != "jax":
@@ -83,7 +94,12 @@ def setup_inverse(method, L, L_lower, sampling, spin, reality, spmd):
     rng = np.random.default_rng()
     flm = s2fft.utils.signal_generator.generate_flm(rng, L, spin=spin, reality=reality)
     precomps = generate_precomputes_jax(
-        L, spin, sampling, forward=False, L_lower=L_lower
+        L,
+        spin,
+        sampling,
+        nside=_get_nside(sampling, L, L_to_nside_ratio),
+        forward=False,
+        L_lower=L_lower,
     )
     if method == "numpy":
         precomps = _jax_arrays_to_numpy(precomps)
@@ -97,10 +113,13 @@ def setup_inverse(method, L, L_lower, sampling, spin, reality, spmd):
     L_lower=L_LOWER_VALUES,
     sampling=SAMPLING_VALUES,
     spin=SPIN_VALUES,
+    L_to_nside_ratio=L_TO_NSIDE_RATIO_VALUES,
     reality=REALITY_VALUES,
     spmd=SPMD_VALUES,
 )
-def inverse(flm, precomps, method, L, L_lower, sampling, spin, reality, spmd):
+def inverse(
+    flm, precomps, method, L, L_lower, sampling, spin, L_to_nside_ratio, reality, spmd
+):
     if method == "pyssht":
         f = pyssht.inverse(samples.flm_2d_to_1d(flm, L), L, spin, sampling.upper())
     else:
@@ -110,6 +129,7 @@ def inverse(flm, precomps, method, L, L_lower, sampling, spin, reality, spmd):
             L_lower=L_lower,
             precomps=precomps,
             spin=spin,
+            nside=_get_nside(sampling, L, L_to_nside_ratio),
             sampling=sampling,
             reality=reality,
             method=method,

--- a/benchmarks/wigner.py
+++ b/benchmarks/wigner.py
@@ -37,7 +37,7 @@ def setup_forward(method, L, L_lower, N, sampling, reality):
     precomps = generate_precomputes(
         L, N, sampling, forward=True, reality=reality, L_lower=L_lower
     )
-    return {"f": f, "precomps": precomps}
+    return {"f": f, "precomps": precomps}, flmn
 
 
 @benchmark(
@@ -62,6 +62,7 @@ def forward(f, precomps, method, L, L_lower, N, sampling, reality):
     )
     if method == "jax":
         flmn.block_until_ready()
+    return flmn
 
 
 def setup_inverse(method, L, L_lower, N, sampling, reality):
@@ -75,7 +76,7 @@ def setup_inverse(method, L, L_lower, N, sampling, reality):
     precomps = generate_precomputes(
         L, N, sampling, forward=False, reality=reality, L_lower=L_lower
     )
-    return {"flmn": flmn, "precomps": precomps}
+    return {"flmn": flmn, "precomps": precomps}, None
 
 
 @benchmark(
@@ -100,6 +101,7 @@ def inverse(flmn, precomps, method, L, L_lower, N, sampling, reality):
     )
     if method == "jax":
         f.block_until_ready()
+    return f
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #254

Updates benchmarks to record round-trip error for forward transforms - that is starting from a set of coefficients and computing a signal by performing inverse transform, computing maximum absolute difference of coefficients recovered using forward transform from signal compared to original reference coefficients.

Also updates benchmarking for JAX functions to use the [static cost and memory analysis available for ahead of time compiled functions](https://jax.readthedocs.io/en/latest/aot.html#debug-information-and-analyses-when-available) to get estimates of operation and memory costs, which should give estimates when running both on CPU and GPU, thus giving some way of tracking memory performance on GPU.

The benchmarks have also been updated to use the standard library `tracemalloc` module to try to trace memory usage when running on a CPU rather than the previous usage of [the `memory_profiler` package](https://pypi.org/project/memory-profiler/) which did give very reliable results. This only gives reasonable values for the NumPy methods (presumably as JAX's memory allocations are transparent to the `tracemalloc` module) but as we don't have the cost / memory analysis statistics for NumPy this is still useful.