### PR TITLE
Make pyssht and healpy optional dependencies

### DIFF
--- a/notebooks/JAX_HEALPix_frontend.ipynb
+++ b/notebooks/JAX_HEALPix_frontend.ipynb
@@ -19,9 +19,9 @@
     "import sys\n",
     "IN_COLAB = 'google.colab' in sys.modules\n",
     "\n",
-    "# Install s2fft and data if running on google colab.\n",
+    "# Install s2fft and healpy if running on google colab.\n",
     "if IN_COLAB:\n",
-    "    !pip install s2fft &> /dev/null"
+    "    !pip install s2fft healpy &> /dev/null"
    ]
   },
   {

--- a/notebooks/JAX_SSHT_frontend.ipynb
+++ b/notebooks/JAX_SSHT_frontend.ipynb
@@ -19,9 +19,9 @@
     "import sys\n",
     "IN_COLAB = 'google.colab' in sys.modules\n",
     "\n",
-    "# Install s2fft and data if running on google colab.\n",
+    "# Install s2fft and pyssht if running on google colab.\n",
     "if IN_COLAB:\n",
-    "    !pip install s2fft &> /dev/null"
+    "    !pip install s2fft pyssht &> /dev/null"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,12 @@ classifiers = [
 ]
 description = "Differentiable and accelerated spherical transforms with JAX"
 dependencies = [
-    "numpy>=1.20,<2",
+    "numpy>=1.20",
     "colorlog",
     "pyyaml",
     "jax>=0.3.13",
     "jaxlib",
     "torch",
-    "pyssht",
-    "healpy",
-    "ducc0",
 ]
 dynamic = [
     "version",
@@ -71,9 +68,13 @@ plotting = [
     "ipywidgets",
 ]
 tests = [
+    "ducc0",
+    "healpy",
+    "numpy<2",  # Required currently due to lack of Numpy v2 compatible pyssht release
     "pytest",
     "pytest-cov",
     "so3",
+    "pyssht",
 ]
 
 [tool.scikit-build]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,10 @@ import pytest
 from jax.test_util import check_grads
 
 from s2fft.sampling import s2_samples as samples
+from s2fft.transforms.c_backend_spherical import (
+    MissingWrapperDependencyError,
+    _try_import_module,
+)
 from s2fft.utils.rotation import generate_rotate_dls, rotate_flms
 
 jax.config.update("jax_enable_x64", True)
@@ -120,3 +124,12 @@ def test_rotate_flms_gradients(
         return jnp.sum(jnp.abs(flm_rot - flm_target))
 
     check_grads(func, (flm_start,), order=1, modes=("rev"))
+
+
+def test_try_import_module():
+    # Use an intentionally long and unlikely to clash module name
+    module_name = "_a_random_module_name_that_should_not_exist"
+    with pytest.raises(
+        MissingWrapperDependencyError, match="requires {module_name} to be installed"
+    ):
+        _try_import_module(module_name)


### PR DESCRIPTION
Related to #229 

Removes `pyssht` and `healpy` from required dependencies for `s2fft` as these are currently only used in tests and in JAX wrapper functions in `s2fft.transforms.c_backend_spherical`. Instead they are now added as test specific dependencies and the  `s2fft.transforms.c_backend_spherical` module updated to try to import these modules when calling the wrapper functions and raise an exception with an informative error message instructing the user they need to install the relevant package to use the wrapper if not already installed.

As the dependency on `pyssht` is what was requiring pinning NumPy to `<2` this resolves #266 as `s2fft` can then be installed with NumPy v2 or above if not installing `pyssht`, although here we still pin the NumPy version in the test dependencies so we are not testing against NumPy v2.