### PR TITLE
Use separate jobs and environment for PyPI and Test PyPI uploading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,13 +74,15 @@ jobs:
           name: cibw-sdist
           path: dist/*.tar.gz
 
-  upload_pypi:
+  upload_test_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: test-pypi
     permissions:
       id-token: write
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: |
+      (github.event_name == 'release' && github.event.action == 'published') || 
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -95,6 +97,20 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist, upload_test_pypi]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
       - name: Publish package distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
           


### PR DESCRIPTION
Resolves #259 

Separates current combined Actions workflow job for uploading to both Test PyPI and PyPI in to separate jobs each with their own dedicated environment, to avoid the issue with attestation file from Test PyPI upload causing PyPI upload to subsequently fail, with runs in separate jobs instead being in isolated environments. This also seems to be [the recommended practice ](https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2463268124).