### PR TITLE
Set up dependabot to automatically update Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds a basic [dependabot configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates) to check weekly for available updates to versions of GitHub Actions used in workflows and open PRs to update.

Should hopefully make it less likely we hit against issues like #281