### PR TITLE
Attempt at resolving errors in building test dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,8 @@ jobs:
           - os: macos-latest
             python-version: "3.8"
       fail-fast: false
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
     - name: Checkout Source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
     - name: Checkout Source
       uses: actions/checkout@v4.2.2
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
May resolve #292

An initial attempt at fixing the issues in building `fftw` as part of building wheels for `pyssht` and `so3` by defining an environment variable `CMAKE_POLICY_VERSION_MINIMUM=3.5` as recommended in associated CMake error.

Also applies similar change to #284 in `actions/checkout` step in publish workflow to tests workflow to ensure tags are checked out and so `setuptools_scm` correctly infers package version when building / installing `s2fft`.