### PR TITLE
Fix incorrect escaping of braces in pre-commit cache key

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ '{{' }} hashFiles('.pre-commit-config.yaml') {{ '}}' }}
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Noticed while reviewing repository workflow caches that key is currently not being computed correctly for pre-commit cache generated as part of linting workflow with double braces being unnecessarily escaped - probably originally arose from copy-pasting from a template file which used `{{ }}` for templating.