### PR TITLE
Convert loops dependent on bandlimit in JAX quadrature rules to functional equivalents

### DIFF
--- a/s2fft/utils/quadrature_jax.py
+++ b/s2fft/utils/quadrature_jax.py
@@ -275,13 +275,7 @@ def quad_weights_mwss_theta_only(L: int) -> jnp.ndarray:
         jnp.ndarray: Weights computed for each :math:`\theta`.
 
     """
-    w = jnp.zeros(2 * L, dtype=jnp.complex128)
-
-    def set_weight_for_index(i, w):
-        return w.at[i + L - 1].set(mw_weights(i - 1))
-
-    w = jax.lax.fori_loop(-(L - 1) + 1, L + 1, set_weight_for_index, w)
-
+    w = jnp.concatenate((jnp.zeros(1), jax.vmap(mw_weights)(jnp.arange(-(L - 1), L))))
     wr = jnp.real(jnp.fft.fft(jnp.fft.ifftshift(w), norm="backward")) / (2 * L)
     q = wr[: L + 1]
     q = q.at[1:L].add(wr[-1:L:-1])
@@ -304,13 +298,7 @@ def quad_weights_mw_theta_only(L: int) -> jnp.ndarray:
         jnp.ndarray: Weights computed for each :math:`\theta`.
 
     """
-    w = jnp.zeros(2 * L - 1, dtype=jnp.complex128)
-
-    def set_weight_for_index(i, w):
-        return w.at[i + L - 1].set(mw_weights(i))
-
-    w = jax.lax.fori_loop(-(L - 1), L, set_weight_for_index, w)
-
+    w = jax.vmap(mw_weights)(jnp.arange(-(L - 1), L))
     w *= jnp.exp(-1j * jnp.arange(-(L - 1), L) * jnp.pi / (2 * L - 1))
     wr = jnp.real(jnp.fft.fft(jnp.fft.ifftshift(w), norm="backward")) / (2 * L - 1)
     q = wr[:L]
@@ -319,7 +307,7 @@ def quad_weights_mw_theta_only(L: int) -> jnp.ndarray:
     return q
 
 
-def mw_weights(m: int, dtype=jnp.complex128) -> float:
+def mw_weights(m: int) -> float:
     r"""
     Compute MW weights given as a function of index m.
 


### PR DESCRIPTION
Relates to #317 

Currently the JAX implementations of the quadrature rules (computations of weights for each $\theta$) used in the forward transform, use native Python for loops for some of the sampling schemes. These loops have a number of iterations which scales with the bandlimit `L`. When JAX traces out these functions as part of its just-in-time compilation transform, the loops are unrolled, resulting in traced JAX expressions (jaxprs) which increase in size as `L` is increased, and an accompanying increase in compilation time due to the larger expression tree / graph being compiled.

[JAX offers functional 'structured' control-flow primitives to side step this issue](https://docs.jax.dev/en/latest/control-flow.html#structured-control-flow-primitives). This PR replaces the native Python for loops in the JAX quadrature rules with an equivalent implementation in terms of [the `jax.lax.fori_loop` function](https://docs.jax.dev/en/latest/_autosummary/jax.lax.fori_loop.html#jax.lax.fori_loop). The changes should not change numerics (beyond floating point differences due to slight rearrangements of ordering of operations) and also not have a significant effect on run-time performance, with the benefit mainly in reduced compilation times. This is borne out in benchmarking (copying results from https://github.com/astro-informatics/s2fft/issues/317#issuecomment-3916111784):

On current `main` (cd8db48)

```
forward
(method: jax, L: 16, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times): 0.00037s, max(run times): 0.00050s, compile time:    0.81s, peak memory: 8.7e+03B, max(abs(error)): 2.9e-14, floating point ops: 4.3e+05, mem access: 1.2e+06B
(method: jax, L: 32, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):  0.0015s, max(run times):  0.0016s, compile time:    0.97s, peak memory: 8.4e+03B, max(abs(error)): 8.1e-14, floating point ops: 2.0e+06, mem access: 5.1e+06B
(method: jax, L: 64, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):  0.0094s, max(run times):   0.011s, compile time:     1.3s, peak memory: 8.4e+03B, max(abs(error)): 2.6e-13, floating point ops: 9.3e+06, mem access: 2.1e+07B
(method: jax, L: 128, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):   0.076s, max(run times):   0.077s, compile time:     2.0s, peak memory: 8.4e+03B, max(abs(error)): 1.9e-12, floating point ops: 4.2e+07, mem access: 9.3e+07B
(method: jax, L: 256, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):    0.94s, max(run times):    0.94s, compile time:     4.4s, peak memory: 8.4e+03B, max(abs(error)): 8.1e-12, floating point ops: 1.9e+08, mem access: 3.7e+08B
(method: jax, L: 512, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):     9.7s, max(run times):     9.9s, compile time:     16.s, peak memory: 8.4e+03B, max(abs(error)): 3.8e-11, floating point ops: 8.3e+08, mem access: 1.5e+09B
```

On `mmg/jaxify-quadrature-loops` branch (5ef1b85) - that is changes in this PR

```
forward
(method: jax, L: 16, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times): 0.00038s, max(run times): 0.00049s, compile time:    0.70s, peak memory: 8.7e+03B, max(abs(error)): 1.5e-14, floating point ops: 4.3e+05, mem access: 1.2e+06B
(method: jax, L: 32, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):  0.0015s, max(run times):  0.0015s, compile time:    0.77s, peak memory: 8.3e+03B, max(abs(error)): 1.3e-13, floating point ops: 2.0e+06, mem access: 5.1e+06B
(method: jax, L: 64, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):   0.011s, max(run times):   0.011s, compile time:    0.71s, peak memory: 8.4e+03B, max(abs(error)): 3.6e-13, floating point ops: 9.3e+06, mem access: 2.1e+07B
(method: jax, L: 128, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):   0.068s, max(run times):   0.070s, compile time:    0.78s, peak memory: 8.3e+03B, max(abs(error)): 1.6e-12, floating point ops: 4.2e+07, mem access: 9.3e+07B
(method: jax, L: 256, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):    0.90s, max(run times):    0.92s, compile time:     1.1s, peak memory: 8.4e+03B, max(abs(error)): 6.8e-12, floating point ops: 1.9e+08, mem access: 3.7e+08B
(method: jax, L: 512, L_lower: 0, sampling: mw, spin: 0, L_to_nside_ratio: 2, reality: True, spmd: False, n_iter: None): 
    min(run times):     9.0s, max(run times):     9.1s, compile time:     1.6s, peak memory: 8.4e+03B, max(abs(error)): 5.4e-11, floating point ops: 8.3e+08, mem access: 1.5e+09B
```

