### PR TITLE
Register HEALPix FFT targets in module-level function

### DIFF
--- a/s2fft/utils/healpix_ffts.py
+++ b/s2fft/utils/healpix_ffts.py
@@ -25,13 +25,6 @@ from s2fft.utils.jax_primitive import register_primitive
 from s2fft.utils.torch_wrapper import wrap_as_torch_function
 
 
-def _register_ffi_targets() -> None:
-    """Register custom call targets for HEALPix FFTs."""
-    if _s2fft is not None:
-        for name, fn in _s2fft.registration().items():
-            jax.ffi.register_ffi_target(name, fn, platform="CUDA")
-
-
 def spectral_folding(fm: np.ndarray, nphi: int, L: int) -> np.ndarray:
     """
     Folds higher frequency Fourier coefficients back onto lower frequency
@@ -562,6 +555,13 @@ def ring_phase_shifts_hp_jax(
 
 
 # Custom healpix_fft_cuda primitive
+
+
+def _register_ffi_targets() -> None:
+    """Register custom call targets for HEALPix FFTs."""
+    if _s2fft is not None:
+        for name, fn in _s2fft.registration().items():
+            jax.ffi.register_ffi_target(name, fn, platform="CUDA")
 
 
 def _get_lowering_info(fft_type, norm, out_dtype):


### PR DESCRIPTION
Closes #364 

A cherry-pick of something I'd ended up moving around locally in my review of #362. Moves the registration of CUDA targets for HEALPix transforms into a function, so it's clear that this portion of code is not meant to be part of another function and is missing an indent.

Also moves the creation of the HEALPix CUDA primitive to the end of the file, and calls the aforementioned created function in the relevant place.

Target is #362 since we depend on changes on that branch, but this doesn't block #362's merging with `main`.