### PR TITLE
Remove unconditional torch import in main package

### DIFF
--- a/s2fft/utils/_dtype_association.py
+++ b/s2fft/utils/_dtype_association.py
@@ -1,9 +1,8 @@
 import jax.numpy as jnp
 import numpy as np
-import torch
 
 
-def compatible_complex_dtype(f: jnp.ndarray | np.ndarray | torch.Tensor) -> str:
+def compatible_complex_dtype(f: jnp.ndarray | np.ndarray) -> str:
     """
     Return the (string specifier of the) smallest complex dtype compatible with ``f``.
 


### PR DESCRIPTION
#368 added a `torch` import in the main package which we shouldn't have as `torch` is not a required dependency of package. As the import was only required for defining `torch.Tensor` type annotation on an input argument I've just removed this completely rather than adding some conditional import logic.