### PR TITLE
Replace custom_vjp with registered JAX primitives for latitudinal step

### DIFF
--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -167,9 +167,7 @@ def _lift_to_batch(arr, ax, batch_size):
     return jnp.moveaxis(arr, ax, 0)
 
 
-def _flm_to_ftm_batcher(
-    batched_args, batch_axes, *, L, nside, sampling, reality, spmd, L_lower
-):
+def _flm_to_ftm_batcher(batched_args, batch_axes, **params):
     flm, thetas, spin, *precomps = batched_args
     flm_ax, thetas_ax, spin_ax, *precomps_ax = batch_axes
     if thetas_ax is not None:
@@ -177,14 +175,6 @@ def _flm_to_ftm_batcher(
             "vmap over `thetas` is not supported (it is determined by the "
             "static sampling configuration)."
         )
-    params = dict(
-        L=L,
-        nside=nside,
-        sampling=sampling,
-        reality=reality,
-        spmd=spmd,
-        L_lower=L_lower,
-    )
     # Identify batch size from the first batched operand.
     arrays_axes = [(flm, flm_ax), (spin, spin_ax)] + list(
         zip(precomps, precomps_ax, strict=False)
@@ -306,9 +296,7 @@ def _ftm_to_flm_transpose(
     return (cot_ftm, None, None) + (None,) * len(precomps)
 
 
-def _ftm_to_flm_batcher(
-    batched_args, batch_axes, *, L, nside, sampling, reality, spmd, L_lower
-):
+def _ftm_to_flm_batcher(batched_args, batch_axes, **params):
     ftm, thetas, spin, *precomps = batched_args
     ftm_ax, thetas_ax, spin_ax, *precomps_ax = batch_axes
     if thetas_ax is not None:
@@ -316,14 +304,6 @@ def _ftm_to_flm_batcher(
             "vmap over `thetas` is not supported (it is determined by the "
             "static sampling configuration)."
         )
-    params = dict(
-        L=L,
-        nside=nside,
-        sampling=sampling,
-        reality=reality,
-        spmd=spmd,
-        L_lower=L_lower,
-    )
     arrays_axes = [(ftm, ftm_ax), (spin, spin_ax)] + list(
         zip(precomps, precomps_ax, strict=False)
     )

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -47,40 +47,6 @@ from s2fft.utils.jax_primitive import register_primitive
 _DATA_NDIM = 2
 
 
-def _underlying_inverse(
-    flm, thetas, spin, precomps, *, L, nside, sampling, reality, spmd, L_lower
-):
-    return otf.inverse_latitudinal_step_jax(
-        flm,
-        thetas,
-        L,
-        spin,
-        nside,
-        sampling,
-        reality,
-        precomps=precomps,
-        spmd=spmd,
-        L_lower=L_lower,
-    )
-
-
-def _underlying_forward(
-    ftm, thetas, spin, precomps, *, L, nside, sampling, reality, spmd, L_lower
-):
-    return otf.forward_latitudinal_step_jax(
-        ftm,
-        thetas,
-        L,
-        spin,
-        nside,
-        sampling,
-        reality,
-        precomps=precomps,
-        spmd=spmd,
-        L_lower=L_lower,
-    )
-
-
 def _apply_with_batching(fn_unbatched, data, spin, precomps):
     """
     Call ``fn_unbatched(data2d, spin0d, precomps_or_None)`` over leading
@@ -116,15 +82,15 @@ def _flm_to_ftm_impl(
     flm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
 ):
     def fn(d, s, p):
-        return _underlying_inverse(
+        return otf.inverse_latitudinal_step_jax(
             d,
             thetas,
+            L,
             s,
-            p,
-            L=L,
-            nside=nside,
-            sampling=sampling,
-            reality=reality,
+            nside,
+            sampling,
+            reality,
+            precomps=p,
             spmd=spmd,
             L_lower=L_lower,
         )
@@ -174,15 +140,15 @@ def _flm_to_ftm_transpose(
     # forward-direction precomps internally (the supplied ones are for the
     # inverse direction).
     def fn(c, s, _ignored_p):
-        return _underlying_forward(
+        return otf.forward_latitudinal_step_jax(
             c,
             thetas,
+            L,
             s,
-            None,
-            L=L,
-            nside=nside,
-            sampling=sampling,
-            reality=reality,
+            nside,
+            sampling,
+            reality,
+            precomps=None,
             spmd=spmd,
             L_lower=L_lower,
         )
@@ -268,15 +234,15 @@ def _ftm_to_flm_impl(
     ftm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
 ):
     def fn(d, s, p):
-        return _underlying_forward(
+        return otf.forward_latitudinal_step_jax(
             d,
             thetas,
+            L,
             s,
-            p,
-            L=L,
-            nside=nside,
-            sampling=sampling,
-            reality=reality,
+            nside,
+            sampling,
+            reality,
+            precomps=p,
             spmd=spmd,
             L_lower=L_lower,
         )
@@ -323,15 +289,15 @@ def _ftm_to_flm_transpose(
     # The transpose of the forward step is the inverse step. We pass
     # ``precomps=None`` so it regenerates the inverse-direction precomps.
     def fn(c, s, _ignored_p):
-        return _underlying_inverse(
+        return otf.inverse_latitudinal_step_jax(
             c,
             thetas,
+            L,
             s,
-            None,
-            L=L,
-            nside=nside,
-            sampling=sampling,
-            reality=reality,
+            nside,
+            sampling,
+            reality,
+            precomps=None,
             spmd=spmd,
             L_lower=L_lower,
         )

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -1,0 +1,460 @@
+"""
+Custom JAX primitives for the latitudinal Wigner-d recursion steps.
+
+The forward (``ftm -> flm``) and inverse (``flm -> ftm``) latitudinal steps
+are linear maps and are transposes of each other. Wrapping them as JAX
+primitives with explicit transpose, JVP and batching rules avoids the
+limitations of ``custom_vjp`` (no transpose rule — breaks under nested
+transforms) and ``linear_call`` (no batching rule).
+
+Each primitive accepts the following operands:
+
+* ``data`` — the array we differentiate w.r.t. (``flm`` or ``ftm``).
+* ``thetas`` — JAX array of polar sample positions (never batched).
+* ``spin`` — 0-d integer JAX array. Must be a JAX operand (not a static
+  kwarg) because the call sites in ``spherical.py`` invoke the primitive
+  while ``spin`` is a JIT tracer.
+* ``*precomps`` — five JAX arrays produced by
+  :func:`generate_precomputes_jax`: ``(lrenorm, vsign, cpi, cp2, indices)``.
+  May be omitted entirely (zero operands), in which case the underlying
+  function regenerates them at trace time.
+
+Static keyword params: ``L``, ``nside``, ``sampling``, ``reality``,
+``spmd``, ``L_lower``.
+
+The primitives are batch-aware: the batcher lifts every operand (other
+than ``thetas``) to share one leading batch dimension, and the abstract
+eval / lowering / transpose then peel off that batch dim via internal
+``vmap``. This means the analytical adjoint (forward <-> inverse step) is
+preserved under ``vmap`` — composed transforms like ``grad(vmap(...))``
+take the analytical-transpose path rather than autodiffing through the
+``log``/``exp`` recursions inside ``otf`` (which can produce ``NaN`` in
+edge cases).
+"""
+
+import jax
+import jax.numpy as jnp
+from jax.core import ShapedArray
+from jax.interpreters import mlir
+
+from s2fft.sampling import s2_samples as samples
+from s2fft.transforms import otf_recursions as otf
+from s2fft.utils.jax_primitive import register_primitive
+
+# Both ``flm`` and ``ftm`` are 2D in the unbatched case; anything past these
+# trailing dims is treated as a batch dimension shared across all batched
+# operands.
+_DATA_NDIM = 2
+
+
+def _underlying_inverse(
+    flm, thetas, spin, precomps, *, L, nside, sampling, reality, spmd, L_lower
+):
+    return otf.inverse_latitudinal_step_jax(
+        flm,
+        thetas,
+        L,
+        spin,
+        nside,
+        sampling,
+        reality,
+        precomps=precomps,
+        spmd=spmd,
+        L_lower=L_lower,
+    )
+
+
+def _underlying_forward(
+    ftm, thetas, spin, precomps, *, L, nside, sampling, reality, spmd, L_lower
+):
+    return otf.forward_latitudinal_step_jax(
+        ftm,
+        thetas,
+        L,
+        spin,
+        nside,
+        sampling,
+        reality,
+        precomps=precomps,
+        spmd=spmd,
+        L_lower=L_lower,
+    )
+
+
+def _apply_with_batching(fn_unbatched, data, spin, precomps):
+    """Call ``fn_unbatched(data2d, spin0d, precomps_or_None)`` over leading
+    batch dims. ``data`` is 2D + batch, ``spin`` is 0d + same batch, each
+    precomp array also has the same number of leading batch dims as ``data``.
+    """
+    n_batch = data.ndim - _DATA_NDIM
+
+    def single(d, s, *ps):
+        precomps_arg = list(ps) if ps else None
+        return fn_unbatched(d, s, precomps_arg)
+
+    inner = single
+    in_axes = (0, 0) + (0,) * len(precomps)
+    for _ in range(n_batch):
+        inner = jax.vmap(inner, in_axes=in_axes)
+    return inner(data, spin, *precomps)
+
+
+# ---------------------------------------------------------------------------
+# flm_to_ftm primitive (inverse latitudinal step)
+# ---------------------------------------------------------------------------
+
+
+def _flm_to_ftm_abstract(
+    flm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
+):
+    out_shape = flm.shape[:-_DATA_NDIM] + samples.ftm_shape(L, sampling, nside)
+    return ShapedArray(out_shape, flm.dtype)
+
+
+def _flm_to_ftm_impl(
+    flm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
+):
+    def fn(d, s, p):
+        return _underlying_inverse(
+            d,
+            thetas,
+            s,
+            p,
+            L=L,
+            nside=nside,
+            sampling=sampling,
+            reality=reality,
+            spmd=spmd,
+            L_lower=L_lower,
+        )
+
+    return _apply_with_batching(fn, flm, spin, precomps)
+
+
+def _flm_to_ftm_jvp(primals, tangents, *, L, nside, sampling, reality, spmd, L_lower):
+    flm, thetas, spin, *precomps = primals
+    flm_t, *_ = tangents
+    primal_out = _flm_to_ftm_primitive.bind(
+        flm,
+        thetas,
+        spin,
+        *precomps,
+        L=L,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
+    )
+    if isinstance(flm_t, jax.interpreters.ad.Zero):
+        tangent_out = jax.interpreters.ad.Zero(primal_out.aval)
+    else:
+        tangent_out = _flm_to_ftm_primitive.bind(
+            flm_t,
+            thetas,
+            spin,
+            *precomps,
+            L=L,
+            nside=nside,
+            sampling=sampling,
+            reality=reality,
+            spmd=spmd,
+            L_lower=L_lower,
+        )
+    return primal_out, tangent_out
+
+
+def _flm_to_ftm_transpose(
+    cotangent, flm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
+):
+    # ``flm`` arrives as an UndefinedPrimal; ``thetas``, ``spin`` and
+    # ``precomps`` are concrete residuals. The transpose of the inverse step
+    # is the forward step. We pass ``precomps=None`` so it regenerates the
+    # forward-direction precomps internally (the supplied ones are for the
+    # inverse direction).
+    def fn(c, s, _ignored_p):
+        return _underlying_forward(
+            c,
+            thetas,
+            s,
+            None,
+            L=L,
+            nside=nside,
+            sampling=sampling,
+            reality=reality,
+            spmd=spmd,
+            L_lower=L_lower,
+        )
+
+    cot_flm = _apply_with_batching(fn, cotangent, spin, precomps)
+    return (cot_flm, None, None) + (None,) * len(precomps)
+
+
+def _lift_to_batch(arr, ax, batch_size):
+    """Move axis ``ax`` to position 0, or broadcast to a leading batch dim
+    of size ``batch_size`` if ``ax is None``."""
+    if ax is None:
+        return jnp.broadcast_to(arr, (batch_size,) + arr.shape)
+    return jnp.moveaxis(arr, ax, 0)
+
+
+def _flm_to_ftm_batcher(
+    batched_args, batch_axes, *, L, nside, sampling, reality, spmd, L_lower
+):
+    flm, thetas, spin, *precomps = batched_args
+    flm_ax, thetas_ax, spin_ax, *precomps_ax = batch_axes
+    if thetas_ax is not None:
+        raise NotImplementedError(
+            "vmap over `thetas` is not supported (it is determined by the "
+            "static sampling configuration)."
+        )
+    params = dict(
+        L=L,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
+    )
+    # Identify batch size from the first batched operand.
+    arrays_axes = [(flm, flm_ax), (spin, spin_ax)] + list(zip(precomps, precomps_ax))
+    batch_size = next(
+        (arr.shape[ax] for arr, ax in arrays_axes if ax is not None),
+        None,
+    )
+    if batch_size is None:
+        return _flm_to_ftm_primitive.bind(flm, thetas, spin, *precomps, **params), None
+    flm_b = _lift_to_batch(flm, flm_ax, batch_size)
+    spin_b = _lift_to_batch(spin, spin_ax, batch_size)
+    precomps_b = tuple(
+        _lift_to_batch(p, ax, batch_size) for p, ax in zip(precomps, precomps_ax)
+    )
+    return _flm_to_ftm_primitive.bind(flm_b, thetas, spin_b, *precomps_b, **params), 0
+
+
+_flm_to_ftm_primitive = register_primitive(
+    "flm_to_ftm",
+    multiple_results=False,
+    abstract_evaluation=_flm_to_ftm_abstract,
+    lowering_per_platform={
+        None: mlir.lower_fun(_flm_to_ftm_impl, multiple_results=False),
+    },
+    batcher=_flm_to_ftm_batcher,
+    jacobian_vector_product=_flm_to_ftm_jvp,
+    transpose=_flm_to_ftm_transpose,
+    is_linear=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# ftm_to_flm primitive (forward latitudinal step)
+# ---------------------------------------------------------------------------
+
+
+def _ftm_to_flm_abstract(
+    ftm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
+):
+    out_shape = ftm.shape[:-_DATA_NDIM] + samples.flm_shape(L)
+    return ShapedArray(out_shape, ftm.dtype)
+
+
+def _ftm_to_flm_impl(
+    ftm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
+):
+    def fn(d, s, p):
+        return _underlying_forward(
+            d,
+            thetas,
+            s,
+            p,
+            L=L,
+            nside=nside,
+            sampling=sampling,
+            reality=reality,
+            spmd=spmd,
+            L_lower=L_lower,
+        )
+
+    return _apply_with_batching(fn, ftm, spin, precomps)
+
+
+def _ftm_to_flm_jvp(primals, tangents, *, L, nside, sampling, reality, spmd, L_lower):
+    ftm, thetas, spin, *precomps = primals
+    ftm_t, *_ = tangents
+    primal_out = _ftm_to_flm_primitive.bind(
+        ftm,
+        thetas,
+        spin,
+        *precomps,
+        L=L,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
+    )
+    if isinstance(ftm_t, jax.interpreters.ad.Zero):
+        tangent_out = jax.interpreters.ad.Zero(primal_out.aval)
+    else:
+        tangent_out = _ftm_to_flm_primitive.bind(
+            ftm_t,
+            thetas,
+            spin,
+            *precomps,
+            L=L,
+            nside=nside,
+            sampling=sampling,
+            reality=reality,
+            spmd=spmd,
+            L_lower=L_lower,
+        )
+    return primal_out, tangent_out
+
+
+def _ftm_to_flm_transpose(
+    cotangent, ftm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
+):
+    # The transpose of the forward step is the inverse step. We pass
+    # ``precomps=None`` so it regenerates the inverse-direction precomps.
+    def fn(c, s, _ignored_p):
+        return _underlying_inverse(
+            c,
+            thetas,
+            s,
+            None,
+            L=L,
+            nside=nside,
+            sampling=sampling,
+            reality=reality,
+            spmd=spmd,
+            L_lower=L_lower,
+        )
+
+    cot_ftm = _apply_with_batching(fn, cotangent, spin, precomps)
+    return (cot_ftm, None, None) + (None,) * len(precomps)
+
+
+def _ftm_to_flm_batcher(
+    batched_args, batch_axes, *, L, nside, sampling, reality, spmd, L_lower
+):
+    ftm, thetas, spin, *precomps = batched_args
+    ftm_ax, thetas_ax, spin_ax, *precomps_ax = batch_axes
+    if thetas_ax is not None:
+        raise NotImplementedError(
+            "vmap over `thetas` is not supported (it is determined by the "
+            "static sampling configuration)."
+        )
+    params = dict(
+        L=L,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
+    )
+    arrays_axes = [(ftm, ftm_ax), (spin, spin_ax)] + list(zip(precomps, precomps_ax))
+    batch_size = next(
+        (arr.shape[ax] for arr, ax in arrays_axes if ax is not None),
+        None,
+    )
+    if batch_size is None:
+        return _ftm_to_flm_primitive.bind(ftm, thetas, spin, *precomps, **params), None
+    ftm_b = _lift_to_batch(ftm, ftm_ax, batch_size)
+    spin_b = _lift_to_batch(spin, spin_ax, batch_size)
+    precomps_b = tuple(
+        _lift_to_batch(p, ax, batch_size) for p, ax in zip(precomps, precomps_ax)
+    )
+    return _ftm_to_flm_primitive.bind(ftm_b, thetas, spin_b, *precomps_b, **params), 0
+
+
+_ftm_to_flm_primitive = register_primitive(
+    "ftm_to_flm",
+    multiple_results=False,
+    abstract_evaluation=_ftm_to_flm_abstract,
+    lowering_per_platform={
+        None: mlir.lower_fun(_ftm_to_flm_impl, multiple_results=False),
+    },
+    batcher=_ftm_to_flm_batcher,
+    jacobian_vector_product=_ftm_to_flm_jvp,
+    transpose=_ftm_to_flm_transpose,
+    is_linear=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Public wrappers
+# ---------------------------------------------------------------------------
+
+
+def _as_spin_operand(spin) -> jnp.ndarray:
+    """Normalize ``spin`` to a 0-d int JAX array. Accepts Python ints,
+    numpy scalars or existing JAX tracers / arrays."""
+    return jnp.asarray(spin, dtype=jnp.int64)
+
+
+def flm_to_ftm(
+    flm: jnp.ndarray,
+    thetas: jnp.ndarray,
+    *,
+    L: int,
+    spin,
+    nside: int | None,
+    sampling: str,
+    reality: bool,
+    spmd: bool,
+    L_lower: int,
+    precomps: list | None = None,
+) -> jnp.ndarray:
+    """Inverse latitudinal step (``flm -> ftm``) via custom JAX primitive.
+
+    If ``precomps`` is None the underlying function regenerates them at
+    trace time; this matches the behaviour of
+    :func:`otf.inverse_latitudinal_step_jax`.
+    """
+    precomps_args = tuple(precomps) if precomps is not None else ()
+    return _flm_to_ftm_primitive.bind(
+        flm,
+        thetas,
+        _as_spin_operand(spin),
+        *precomps_args,
+        L=L,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
+    )
+
+
+def ftm_to_flm(
+    ftm: jnp.ndarray,
+    thetas: jnp.ndarray,
+    *,
+    L: int,
+    spin,
+    nside: int | None,
+    sampling: str,
+    reality: bool,
+    spmd: bool,
+    L_lower: int,
+    precomps: list | None = None,
+) -> jnp.ndarray:
+    """Forward latitudinal step (``ftm -> flm``) via custom JAX primitive.
+
+    If ``precomps`` is None the underlying function regenerates them at
+    trace time; this matches the behaviour of
+    :func:`otf.forward_latitudinal_step_jax`.
+    """
+    precomps_args = tuple(precomps) if precomps is not None else ()
+    return _ftm_to_flm_primitive.bind(
+        ftm,
+        thetas,
+        _as_spin_operand(spin),
+        *precomps_args,
+        L=L,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
+    )

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -47,6 +47,11 @@ from s2fft.utils.jax_primitive import register_primitive
 _DATA_NDIM = 2
 
 
+# ---------------------------------------------------------------------------
+# Helper functions for constructing primitives
+# ---------------------------------------------------------------------------
+
+
 def _apply_with_batching(fn_unbatched, data, spin, precomps):
     """
     Call ``fn_unbatched(data2d, spin0d, precomps_or_None)`` over leading
@@ -67,6 +72,24 @@ def _tuplify_precomps(precomps: list | None) -> tuple:
 
 def _untuplify_precomps(precomps: tuple) -> list | None:
     return list(precomps) if precomps else None
+
+
+def _as_spin_operand(spin) -> jnp.ndarray:
+    """
+    Normalize ``spin`` to a 0-d int JAX array. Accepts Python ints,
+    numpy scalars or existing JAX tracers / arrays.
+    """
+    return jnp.asarray(spin, dtype=jnp.int64)
+
+
+def _lift_to_batch(arr, ax, batch_size):
+    """
+    Move axis ``ax`` to position 0, or broadcast to a leading batch dim
+    of size ``batch_size`` if ``ax is None``.
+    """
+    if ax is None:
+        return jnp.broadcast_to(arr, (batch_size,) + arr.shape)
+    return jnp.moveaxis(arr, ax, 0)
 
 
 def _batch_primitive(primitive, batched_args, batch_axes, **params):
@@ -147,16 +170,6 @@ def _flm_to_ftm_transpose(cotangent, flm, thetas, spin, *precomps, **params):
 
     cot_flm = _apply_with_batching(fn, cotangent, spin, precomps)
     return (cot_flm, None, None) + (None,) * len(precomps)
-
-
-def _lift_to_batch(arr, ax, batch_size):
-    """
-    Move axis ``ax`` to position 0, or broadcast to a leading batch dim
-    of size ``batch_size`` if ``ax is None``.
-    """
-    if ax is None:
-        return jnp.broadcast_to(arr, (batch_size,) + arr.shape)
-    return jnp.moveaxis(arr, ax, 0)
 
 
 def _flm_to_ftm_batcher(batched_args, batch_axes, **params):
@@ -244,14 +257,6 @@ _ftm_to_flm_primitive = register_primitive(
 # ---------------------------------------------------------------------------
 # Public wrappers
 # ---------------------------------------------------------------------------
-
-
-def _as_spin_operand(spin) -> jnp.ndarray:
-    """
-    Normalize ``spin`` to a 0-d int JAX array. Accepts Python ints,
-    numpy scalars or existing JAX tracers / arrays.
-    """
-    return jnp.asarray(spin, dtype=jnp.int64)
 
 
 def flm_to_ftm(

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -69,6 +69,37 @@ def _untuplify_precomps(precomps: tuple) -> list | None:
     return list(precomps) if precomps else None
 
 
+def _batch_primitive(primitive, batched_args, batch_axes, **params):
+    """
+    Batch ftm_to_flm or flm_to_ftm primitive given batched_args with first
+    argument corresponding to either ftm or flm array (fxm used as placeholder).
+    """
+    fxm, thetas, spin, *precomps = batched_args
+    fxm_ax, thetas_ax, spin_ax, *precomps_ax = batch_axes
+    if thetas_ax is not None:
+        raise NotImplementedError(
+            "vmap over `thetas` is not supported (it is determined by the "
+            "static sampling configuration)."
+        )
+    # Identify batch size from the first batched operand.
+    arrays_axes = [(fxm, fxm_ax), (spin, spin_ax)] + list(
+        zip(precomps, precomps_ax, strict=False)
+    )
+    batch_size = next(
+        (arr.shape[ax] for arr, ax in arrays_axes if ax is not None),
+        None,
+    )
+    if batch_size is None:
+        return primitive.bind(fxm, thetas, spin, *precomps, **params), None
+    fxm_b = _lift_to_batch(fxm, fxm_ax, batch_size)
+    spin_b = _lift_to_batch(spin, spin_ax, batch_size)
+    precomps_b = tuple(
+        _lift_to_batch(p, ax, batch_size)
+        for p, ax in zip(precomps, precomps_ax, strict=False)
+    )
+    return primitive.bind(fxm_b, thetas, spin_b, *precomps_b, **params), 0
+
+
 # ---------------------------------------------------------------------------
 # flm_to_ftm primitive (inverse latitudinal step)
 # ---------------------------------------------------------------------------
@@ -129,30 +160,7 @@ def _lift_to_batch(arr, ax, batch_size):
 
 
 def _flm_to_ftm_batcher(batched_args, batch_axes, **params):
-    flm, thetas, spin, *precomps = batched_args
-    flm_ax, thetas_ax, spin_ax, *precomps_ax = batch_axes
-    if thetas_ax is not None:
-        raise NotImplementedError(
-            "vmap over `thetas` is not supported (it is determined by the "
-            "static sampling configuration)."
-        )
-    # Identify batch size from the first batched operand.
-    arrays_axes = [(flm, flm_ax), (spin, spin_ax)] + list(
-        zip(precomps, precomps_ax, strict=False)
-    )
-    batch_size = next(
-        (arr.shape[ax] for arr, ax in arrays_axes if ax is not None),
-        None,
-    )
-    if batch_size is None:
-        return _flm_to_ftm_primitive.bind(flm, thetas, spin, *precomps, **params), None
-    flm_b = _lift_to_batch(flm, flm_ax, batch_size)
-    spin_b = _lift_to_batch(spin, spin_ax, batch_size)
-    precomps_b = tuple(
-        _lift_to_batch(p, ax, batch_size)
-        for p, ax in zip(precomps, precomps_ax, strict=False)
-    )
-    return _flm_to_ftm_primitive.bind(flm_b, thetas, spin_b, *precomps_b, **params), 0
+    return _batch_primitive(_flm_to_ftm_primitive, batched_args, batch_axes, **params)
 
 
 _flm_to_ftm_primitive = register_primitive(
@@ -216,29 +224,7 @@ def _ftm_to_flm_transpose(cotangent, ftm, thetas, spin, *precomps, **params):
 
 
 def _ftm_to_flm_batcher(batched_args, batch_axes, **params):
-    ftm, thetas, spin, *precomps = batched_args
-    ftm_ax, thetas_ax, spin_ax, *precomps_ax = batch_axes
-    if thetas_ax is not None:
-        raise NotImplementedError(
-            "vmap over `thetas` is not supported (it is determined by the "
-            "static sampling configuration)."
-        )
-    arrays_axes = [(ftm, ftm_ax), (spin, spin_ax)] + list(
-        zip(precomps, precomps_ax, strict=False)
-    )
-    batch_size = next(
-        (arr.shape[ax] for arr, ax in arrays_axes if ax is not None),
-        None,
-    )
-    if batch_size is None:
-        return _ftm_to_flm_primitive.bind(ftm, thetas, spin, *precomps, **params), None
-    ftm_b = _lift_to_batch(ftm, ftm_ax, batch_size)
-    spin_b = _lift_to_batch(spin, spin_ax, batch_size)
-    precomps_b = tuple(
-        _lift_to_batch(p, ax, batch_size)
-        for p, ax in zip(precomps, precomps_ax, strict=False)
-    )
-    return _ftm_to_flm_primitive.bind(ftm_b, thetas, spin_b, *precomps_b, **params), 0
+    return _batch_primitive(_ftm_to_flm_primitive, batched_args, batch_axes, **params)
 
 
 _ftm_to_flm_primitive = register_primitive(

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -78,21 +78,10 @@ def _flm_to_ftm_abstract(
     return ShapedArray(out_shape, flm.dtype)
 
 
-def _flm_to_ftm_impl(
-    flm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
-):
+def _flm_to_ftm_impl(flm, thetas, spin, *precomps, **params):
     def fn(d, s, p):
         return otf.inverse_latitudinal_step_jax(
-            d,
-            thetas,
-            L,
-            s,
-            nside,
-            sampling,
-            reality,
-            precomps=p,
-            spmd=spmd,
-            L_lower=L_lower,
+            flm=d, beta=thetas, spin=s, precomps=p, **params
         )
 
     return _apply_with_batching(fn, flm, spin, precomps)
@@ -111,9 +100,7 @@ def _flm_to_ftm_jvp(primals, tangents, **params):
     return primal_out, tangent_out
 
 
-def _flm_to_ftm_transpose(
-    cotangent, flm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
-):
+def _flm_to_ftm_transpose(cotangent, flm, thetas, spin, *precomps, **params):
     # ``flm`` arrives as an UndefinedPrimal; ``thetas``, ``spin`` and
     # ``precomps`` are concrete residuals. The transpose of the inverse step
     # is the forward step. We pass ``precomps=None`` so it regenerates the
@@ -121,16 +108,7 @@ def _flm_to_ftm_transpose(
     # inverse direction).
     def fn(c, s, _ignored_p):
         return otf.forward_latitudinal_step_jax(
-            c,
-            thetas,
-            L,
-            s,
-            nside,
-            sampling,
-            reality,
-            precomps=None,
-            spmd=spmd,
-            L_lower=L_lower,
+            ftm_in=c, beta_in=thetas, spin=s, precomps=None, **params
         )
 
     cot_flm = _apply_with_batching(fn, cotangent, spin, precomps)
@@ -200,21 +178,10 @@ def _ftm_to_flm_abstract(
     return ShapedArray(out_shape, ftm.dtype)
 
 
-def _ftm_to_flm_impl(
-    ftm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
-):
+def _ftm_to_flm_impl(ftm, thetas, spin, *precomps, **params):
     def fn(d, s, p):
         return otf.forward_latitudinal_step_jax(
-            d,
-            thetas,
-            L,
-            s,
-            nside,
-            sampling,
-            reality,
-            precomps=p,
-            spmd=spmd,
-            L_lower=L_lower,
+            ftm_in=d, beta_in=thetas, spin=s, precomps=p, **params
         )
 
     return _apply_with_batching(fn, ftm, spin, precomps)
@@ -233,23 +200,12 @@ def _ftm_to_flm_jvp(primals, tangents, **params):
     return primal_out, tangent_out
 
 
-def _ftm_to_flm_transpose(
-    cotangent, ftm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
-):
+def _ftm_to_flm_transpose(cotangent, ftm, thetas, spin, *precomps, **params):
     # The transpose of the forward step is the inverse step. We pass
     # ``precomps=None`` so it regenerates the inverse-direction precomps.
     def fn(c, s, _ignored_p):
         return otf.inverse_latitudinal_step_jax(
-            c,
-            thetas,
-            L,
-            s,
-            nside,
-            sampling,
-            reality,
-            precomps=None,
-            spmd=spmd,
-            L_lower=L_lower,
+            flm=c, beta=thetas, spin=s, precomps=None, **params
         )
 
     cot_ftm = _apply_with_batching(fn, cotangent, spin, precomps)

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -82,7 +82,8 @@ def _underlying_forward(
 
 
 def _apply_with_batching(fn_unbatched, data, spin, precomps):
-    """Call ``fn_unbatched(data2d, spin0d, precomps_or_None)`` over leading
+    """
+    Call ``fn_unbatched(data2d, spin0d, precomps_or_None)`` over leading
     batch dims. ``data`` is 2D + batch, ``spin`` is 0d + same batch, each
     precomp array also has the same number of leading batch dims as ``data``.
     """
@@ -191,8 +192,10 @@ def _flm_to_ftm_transpose(
 
 
 def _lift_to_batch(arr, ax, batch_size):
-    """Move axis ``ax`` to position 0, or broadcast to a leading batch dim
-    of size ``batch_size`` if ``ax is None``."""
+    """
+    Move axis ``ax`` to position 0, or broadcast to a leading batch dim
+    of size ``batch_size`` if ``ax is None``.
+    """
     if ax is None:
         return jnp.broadcast_to(arr, (batch_size,) + arr.shape)
     return jnp.moveaxis(arr, ax, 0)
@@ -217,7 +220,9 @@ def _flm_to_ftm_batcher(
         L_lower=L_lower,
     )
     # Identify batch size from the first batched operand.
-    arrays_axes = [(flm, flm_ax), (spin, spin_ax)] + list(zip(precomps, precomps_ax))
+    arrays_axes = [(flm, flm_ax), (spin, spin_ax)] + list(
+        zip(precomps, precomps_ax, strict=False)
+    )
     batch_size = next(
         (arr.shape[ax] for arr, ax in arrays_axes if ax is not None),
         None,
@@ -227,7 +232,8 @@ def _flm_to_ftm_batcher(
     flm_b = _lift_to_batch(flm, flm_ax, batch_size)
     spin_b = _lift_to_batch(spin, spin_ax, batch_size)
     precomps_b = tuple(
-        _lift_to_batch(p, ax, batch_size) for p, ax in zip(precomps, precomps_ax)
+        _lift_to_batch(p, ax, batch_size)
+        for p, ax in zip(precomps, precomps_ax, strict=False)
     )
     return _flm_to_ftm_primitive.bind(flm_b, thetas, spin_b, *precomps_b, **params), 0
 
@@ -352,7 +358,9 @@ def _ftm_to_flm_batcher(
         spmd=spmd,
         L_lower=L_lower,
     )
-    arrays_axes = [(ftm, ftm_ax), (spin, spin_ax)] + list(zip(precomps, precomps_ax))
+    arrays_axes = [(ftm, ftm_ax), (spin, spin_ax)] + list(
+        zip(precomps, precomps_ax, strict=False)
+    )
     batch_size = next(
         (arr.shape[ax] for arr, ax in arrays_axes if ax is not None),
         None,
@@ -362,7 +370,8 @@ def _ftm_to_flm_batcher(
     ftm_b = _lift_to_batch(ftm, ftm_ax, batch_size)
     spin_b = _lift_to_batch(spin, spin_ax, batch_size)
     precomps_b = tuple(
-        _lift_to_batch(p, ax, batch_size) for p, ax in zip(precomps, precomps_ax)
+        _lift_to_batch(p, ax, batch_size)
+        for p, ax in zip(precomps, precomps_ax, strict=False)
     )
     return _ftm_to_flm_primitive.bind(ftm_b, thetas, spin_b, *precomps_b, **params), 0
 
@@ -387,8 +396,10 @@ _ftm_to_flm_primitive = register_primitive(
 
 
 def _as_spin_operand(spin) -> jnp.ndarray:
-    """Normalize ``spin`` to a 0-d int JAX array. Accepts Python ints,
-    numpy scalars or existing JAX tracers / arrays."""
+    """
+    Normalize ``spin`` to a 0-d int JAX array. Accepts Python ints,
+    numpy scalars or existing JAX tracers / arrays.
+    """
     return jnp.asarray(spin, dtype=jnp.int64)
 
 
@@ -405,7 +416,8 @@ def flm_to_ftm(
     L_lower: int,
     precomps: list | None = None,
 ) -> jnp.ndarray:
-    """Inverse latitudinal step (``flm -> ftm``) via custom JAX primitive.
+    """
+    Inverse latitudinal step (``flm -> ftm``) via custom JAX primitive.
 
     If ``precomps`` is None the underlying function regenerates them at
     trace time; this matches the behaviour of
@@ -439,7 +451,8 @@ def ftm_to_flm(
     L_lower: int,
     precomps: list | None = None,
 ) -> jnp.ndarray:
-    """Forward latitudinal step (``ftm -> flm``) via custom JAX primitive.
+    """
+    Forward latitudinal step (``ftm -> flm``) via custom JAX primitive.
 
     If ``precomps`` is None the underlying function regenerates them at
     trace time; this matches the behaviour of

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -98,35 +98,15 @@ def _flm_to_ftm_impl(
     return _apply_with_batching(fn, flm, spin, precomps)
 
 
-def _flm_to_ftm_jvp(primals, tangents, *, L, nside, sampling, reality, spmd, L_lower):
+def _flm_to_ftm_jvp(primals, tangents, **params):
     flm, thetas, spin, *precomps = primals
     flm_t, *_ = tangents
-    primal_out = _flm_to_ftm_primitive.bind(
-        flm,
-        thetas,
-        spin,
-        *precomps,
-        L=L,
-        nside=nside,
-        sampling=sampling,
-        reality=reality,
-        spmd=spmd,
-        L_lower=L_lower,
-    )
+    primal_out = _flm_to_ftm_primitive.bind(flm, thetas, spin, *precomps, **params)
     if isinstance(flm_t, jax.interpreters.ad.Zero):
         tangent_out = jax.interpreters.ad.Zero(primal_out.aval)
     else:
         tangent_out = _flm_to_ftm_primitive.bind(
-            flm_t,
-            thetas,
-            spin,
-            *precomps,
-            L=L,
-            nside=nside,
-            sampling=sampling,
-            reality=reality,
-            spmd=spmd,
-            L_lower=L_lower,
+            flm_t, thetas, spin, *precomps, **params
         )
     return primal_out, tangent_out
 
@@ -240,35 +220,15 @@ def _ftm_to_flm_impl(
     return _apply_with_batching(fn, ftm, spin, precomps)
 
 
-def _ftm_to_flm_jvp(primals, tangents, *, L, nside, sampling, reality, spmd, L_lower):
+def _ftm_to_flm_jvp(primals, tangents, **params):
     ftm, thetas, spin, *precomps = primals
     ftm_t, *_ = tangents
-    primal_out = _ftm_to_flm_primitive.bind(
-        ftm,
-        thetas,
-        spin,
-        *precomps,
-        L=L,
-        nside=nside,
-        sampling=sampling,
-        reality=reality,
-        spmd=spmd,
-        L_lower=L_lower,
-    )
+    primal_out = _ftm_to_flm_primitive.bind(ftm, thetas, spin, *precomps, **params)
     if isinstance(ftm_t, jax.interpreters.ad.Zero):
         tangent_out = jax.interpreters.ad.Zero(primal_out.aval)
     else:
         tangent_out = _ftm_to_flm_primitive.bind(
-            ftm_t,
-            thetas,
-            spin,
-            *precomps,
-            L=L,
-            nside=nside,
-            sampling=sampling,
-            reality=reality,
-            spmd=spmd,
-            L_lower=L_lower,
+            ftm_t, thetas, spin, *precomps, **params
         )
     return primal_out, tangent_out
 

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -54,16 +54,19 @@ def _apply_with_batching(fn_unbatched, data, spin, precomps):
     precomp array also has the same number of leading batch dims as ``data``.
     """
     n_batch = data.ndim - _DATA_NDIM
-
-    def single(d, s, *ps):
-        precomps_arg = list(ps) if ps else None
-        return fn_unbatched(d, s, precomps_arg)
-
-    inner = single
-    in_axes = (0, 0) + (0,) * len(precomps)
+    inner = fn_unbatched
+    in_axes = (0, 0, (0,) * len(precomps))
     for _ in range(n_batch):
         inner = jax.vmap(inner, in_axes=in_axes)
-    return inner(data, spin, *precomps)
+    return inner(data, spin, precomps)
+
+
+def _tuplify_precomps(precomps: list | None) -> tuple:
+    return tuple(precomps) if precomps is not None else ()
+
+
+def _untuplify_precomps(precomps: tuple) -> list | None:
+    return list(precomps) if precomps else None
 
 
 # ---------------------------------------------------------------------------
@@ -81,7 +84,7 @@ def _flm_to_ftm_abstract(
 def _flm_to_ftm_impl(flm, thetas, spin, *precomps, **params):
     def fn(d, s, p):
         return otf.inverse_latitudinal_step_jax(
-            flm=d, beta=thetas, spin=s, precomps=p, **params
+            flm=d, beta=thetas, spin=s, precomps=_untuplify_precomps(p), **params
         )
 
     return _apply_with_batching(fn, flm, spin, precomps)
@@ -181,7 +184,7 @@ def _ftm_to_flm_abstract(
 def _ftm_to_flm_impl(ftm, thetas, spin, *precomps, **params):
     def fn(d, s, p):
         return otf.forward_latitudinal_step_jax(
-            ftm_in=d, beta_in=thetas, spin=s, precomps=p, **params
+            ftm_in=d, beta_in=thetas, spin=s, precomps=_untuplify_precomps(p), **params
         )
 
     return _apply_with_batching(fn, ftm, spin, precomps)
@@ -285,12 +288,11 @@ def flm_to_ftm(
     trace time; this matches the behaviour of
     :func:`otf.inverse_latitudinal_step_jax`.
     """
-    precomps_args = tuple(precomps) if precomps is not None else ()
     return _flm_to_ftm_primitive.bind(
         flm,
         thetas,
         _as_spin_operand(spin),
-        *precomps_args,
+        *_tuplify_precomps(precomps),
         L=L,
         nside=nside,
         sampling=sampling,
@@ -320,12 +322,11 @@ def ftm_to_flm(
     trace time; this matches the behaviour of
     :func:`otf.forward_latitudinal_step_jax`.
     """
-    precomps_args = tuple(precomps) if precomps is not None else ()
     return _ftm_to_flm_primitive.bind(
         ftm,
         thetas,
         _as_spin_operand(spin),
-        *precomps_args,
+        *_tuplify_precomps(precomps),
         L=L,
         nside=nside,
         sampling=sampling,

--- a/s2fft/transforms/spherical.py
+++ b/s2fft/transforms/spherical.py
@@ -2,9 +2,10 @@ from functools import partial
 
 import jax.numpy as jnp
 import numpy as np
-from jax import custom_vjp, jit
+from jax import jit
 
 from s2fft.sampling import s2_samples as samples
+from s2fft.transforms import _ftm_flm_primitive as ftm_flm_prim
 from s2fft.transforms import c_backend_spherical as c_sph
 from s2fft.transforms import otf_recursions as otf
 from s2fft.utils import healpix_ffts as hp
@@ -287,42 +288,22 @@ def inverse_jax(
         )
     )
 
-    # Perform latitudinal wigner-d recursions
-    @custom_vjp
-    def flm_to_ftm(flm, spin, precomps):
-        return otf.inverse_latitudinal_step_jax(
-            flm,
-            thetas,
-            L,
-            spin,
-            nside,
-            sampling,
-            reality,
-            precomps=precomps,
-            spmd=spmd,
-            L_lower=L_lower,
-        )
-
-    def f_fwd(flm, spin, precomps):
-        return flm_to_ftm(flm, spin, precomps), ([], spin, [])
-
-    def f_bwd(res, gtm):
-        spin = res[1]
-        glm = otf.forward_latitudinal_step_jax(
-            gtm,
-            thetas,
-            L,
-            spin,
-            nside,
-            sampling,
-            reality,
-            spmd=spmd,
-            L_lower=L_lower,
-        )
-        return glm, None, None
-
-    flm_to_ftm.defvjp(f_fwd, f_bwd)
-    ftm = flm_to_ftm(flm, spin, precomps)
+    # Perform latitudinal wigner-d recursions via custom JAX primitive.
+    # The primitive registers transpose, JVP and vmap rules so that grad,
+    # vmap, and their compositions all work without falling back to the
+    # generic ``custom_vjp`` machinery.
+    ftm = ftm_flm_prim.flm_to_ftm(
+        flm,
+        thetas,
+        L=L,
+        spin=spin,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
+        precomps=precomps,
+    )
 
     # Correct healpix theta row offsets
     if sampling.lower() == "healpix":
@@ -691,43 +672,22 @@ def forward_jax(
         phase_shifts = hp.ring_phase_shifts_hp_jax(L, nside, True, reality)
         ftm = ftm.at[:, m_start_ind + m_offset :].multiply(phase_shifts)
 
-    # Perform latitudinal wigner-d recursions
-    @custom_vjp
-    def ftm_to_flm(ftm, spin, precomps):
-        flm = otf.forward_latitudinal_step_jax(
-            ftm,
-            thetas,
-            L,
-            spin,
-            nside,
-            sampling,
-            reality,
-            precomps=precomps,
-            spmd=spmd,
-            L_lower=L_lower,
-        )
-        return flm
-
-    def f_fwd(ftm, spin, precomps):
-        return ftm_to_flm(ftm, spin, precomps), ([], spin, [])
-
-    def f_bwd(res, glm):
-        spin = res[1]
-        gtm = otf.inverse_latitudinal_step_jax(
-            glm,
-            thetas,
-            L,
-            spin,
-            nside,
-            sampling,
-            reality,
-            spmd=spmd,
-            L_lower=L_lower,
-        )
-        return gtm, None, None
-
-    ftm_to_flm.defvjp(f_fwd, f_bwd)
-    flm = ftm_to_flm(ftm, spin, precomps)
+    # Perform latitudinal wigner-d recursions via custom JAX primitive.
+    # The primitive registers transpose, JVP and vmap rules so that grad,
+    # vmap, and their compositions all work without falling back to the
+    # generic ``custom_vjp`` machinery.
+    flm = ftm_flm_prim.ftm_to_flm(
+        ftm,
+        thetas,
+        L=L,
+        spin=spin,
+        nside=nside,
+        sampling=sampling,
+        reality=reality,
+        spmd=spmd,
+        L_lower=L_lower,
+        precomps=precomps,
+    )
 
     # Apply harmonic normalisation
     flm = flm.at[L_lower:].set(

--- a/tests/test_ftm_flm_primitive.py
+++ b/tests/test_ftm_flm_primitive.py
@@ -10,8 +10,6 @@ These tests verify:
    result equals an explicit Python loop.
 4. **Composed transforms** — ``vmap(grad(...))`` and ``grad(vmap(...))``
    both produce the same result as a manual loop.
-5. **End-to-end** — ``forward_jax`` / ``inverse_jax`` still match
-   ``forward_numpy`` / ``inverse_numpy`` after the primitive replacement.
 """
 
 import jax
@@ -24,7 +22,6 @@ from s2fft.recursions.price_mcewen import generate_precomputes_jax
 from s2fft.sampling import s2_samples as samples
 from s2fft.transforms import _ftm_flm_primitive as ftm_flm_prim
 from s2fft.transforms import otf_recursions as otf
-from s2fft.transforms import spherical
 
 jax.config.update("jax_enable_x64", True)
 
@@ -428,41 +425,3 @@ def test_vmap_of_grad_ftm_to_flm(rng):
     via_vmap = jax.vmap(per_sample_grad)(ftms)
     via_loop = jnp.stack([per_sample_grad(ftms[i]) for i in range(batch)])
     np.testing.assert_allclose(np.asarray(via_vmap), np.asarray(via_loop), atol=1e-10)
-
-
-# ---------------------------------------------------------------------------
-# 5. End-to-end: full forward / inverse spherical transform after the swap
-# ---------------------------------------------------------------------------
-
-
-def _spin_valid_flm(rng, L, spin):
-    """Random flm satisfying the spin condition ``flm[:|s|] == 0``."""
-    flm = (
-        rng.standard_normal(samples.flm_shape(L))
-        + 1j * rng.standard_normal(samples.flm_shape(L))
-    ).astype(np.complex128)
-    flm[: abs(spin)] = 0.0
-    return flm
-
-
-@pytest.mark.parametrize("spin", [0, 1])
-@pytest.mark.parametrize("sampling", ["mw", "mwss", "dh", "gl"])
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_inverse_jax_matches_inverse_numpy(spin, sampling, rng):
-    L = L_TEST
-    flm = _spin_valid_flm(rng, L, spin)
-    expected = spherical.inverse_numpy(flm, L, spin=spin, sampling=sampling)
-    actual = spherical.inverse_jax(jnp.asarray(flm), L, spin=spin, sampling=sampling)
-    np.testing.assert_allclose(np.asarray(actual), expected, atol=1e-10)
-
-
-@pytest.mark.parametrize("spin", [0, 1])
-@pytest.mark.parametrize("sampling", ["mw", "mwss", "dh", "gl"])
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_forward_jax_matches_forward_numpy(spin, sampling, rng):
-    L = L_TEST
-    flm = _spin_valid_flm(rng, L, spin)
-    f = spherical.inverse_numpy(flm, L, spin=spin, sampling=sampling)
-    expected = spherical.forward_numpy(f, L, spin=spin, sampling=sampling)
-    actual = spherical.forward_jax(jnp.asarray(f), L, spin=spin, sampling=sampling)
-    np.testing.assert_allclose(np.asarray(actual), expected, atol=1e-9)

--- a/tests/test_ftm_flm_primitive.py
+++ b/tests/test_ftm_flm_primitive.py
@@ -171,8 +171,8 @@ def test_flm_to_ftm_matches_with_explicit_precomps(sampling):
 def test_flm_to_ftm_grad(spin, sampling):
     flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
 
-    def loss(flm):
-        ftm = ftm_flm_prim.flm_to_ftm(
+    def flm_to_ftm(flm):
+        return ftm_flm_prim.flm_to_ftm(
             flm,
             thetas,
             L=L_TEST,
@@ -184,9 +184,8 @@ def test_flm_to_ftm_grad(spin, sampling):
             L_lower=L_LOWER_TEST,
             precomps=None,
         )
-        return jnp.sum(jnp.abs(ftm) ** 2)
 
-    check_grads(loss, (flm,), order=1, modes=("rev",), atol=1e-3, rtol=1e-3)
+    check_grads(flm_to_ftm, (flm,), order=2, modes=("fwd", "rev"))
 
 
 @pytest.mark.parametrize("spin", SPIN_TEST)
@@ -194,8 +193,8 @@ def test_flm_to_ftm_grad(spin, sampling):
 def test_ftm_to_flm_grad(spin, sampling):
     _, ftm, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
 
-    def loss(ftm):
-        flm = ftm_flm_prim.ftm_to_flm(
+    def ftm_to_flm(ftm):
+        return ftm_flm_prim.ftm_to_flm(
             ftm,
             thetas,
             L=L_TEST,
@@ -207,9 +206,9 @@ def test_ftm_to_flm_grad(spin, sampling):
             L_lower=L_LOWER_TEST,
             precomps=None,
         )
-        return jnp.sum(jnp.abs(flm) ** 2)
 
-    check_grads(loss, (ftm,), order=1, modes=("rev",), atol=1e-3, rtol=1e-3)
+    # TODO: figure out why this fails for MWSS scheme for order=2
+    check_grads(ftm_to_flm, (ftm,), order=1, modes=("fwd", "rev"))
 
 
 def test_grad_matches_direct_otf_call():

--- a/tests/test_ftm_flm_primitive.py
+++ b/tests/test_ftm_flm_primitive.py
@@ -37,8 +37,7 @@ SPIN_TEST = [-2, 0, 1]
 SAMPLING_TEST = ["mw", "mwss", "dh", "gl"]
 
 
-def _make_inputs(L, spin, sampling, reality, rng_seed=0):
-    rng = np.random.default_rng(rng_seed)
+def _make_inputs(rng, L, spin, sampling, reality):
     flm = (
         rng.standard_normal(samples.flm_shape(L))
         + 1j * rng.standard_normal(samples.flm_shape(L))
@@ -61,8 +60,8 @@ def _make_inputs(L, spin, sampling, reality, rng_seed=0):
 
 @pytest.mark.parametrize("spin", SPIN_TEST)
 @pytest.mark.parametrize("sampling", SAMPLING_TEST)
-def test_flm_to_ftm_matches_otf(spin, sampling):
-    flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+def test_flm_to_ftm_matches_otf(spin, sampling, rng):
+    flm, _, thetas = _make_inputs(rng, L_TEST, spin, sampling, reality=False)
     expected = otf.inverse_latitudinal_step_jax(
         flm,
         thetas,
@@ -92,8 +91,8 @@ def test_flm_to_ftm_matches_otf(spin, sampling):
 
 @pytest.mark.parametrize("spin", SPIN_TEST)
 @pytest.mark.parametrize("sampling", SAMPLING_TEST)
-def test_ftm_to_flm_matches_otf(spin, sampling):
-    _, ftm, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+def test_ftm_to_flm_matches_otf(spin, sampling, rng):
+    _, ftm, thetas = _make_inputs(rng, L_TEST, spin, sampling, reality=False)
     expected = otf.forward_latitudinal_step_jax(
         ftm,
         thetas,
@@ -122,9 +121,9 @@ def test_ftm_to_flm_matches_otf(spin, sampling):
 
 
 @pytest.mark.parametrize("sampling", SAMPLING_TEST)
-def test_flm_to_ftm_matches_with_explicit_precomps(sampling):
+def test_flm_to_ftm_matches_with_explicit_precomps(sampling, rng):
     spin = 1
-    flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+    flm, _, thetas = _make_inputs(rng, L_TEST, spin, sampling, reality=False)
     precomps = generate_precomputes_jax(
         L_TEST,
         spin,
@@ -168,8 +167,8 @@ def test_flm_to_ftm_matches_with_explicit_precomps(sampling):
 
 @pytest.mark.parametrize("spin", SPIN_TEST)
 @pytest.mark.parametrize("sampling", SAMPLING_TEST)
-def test_flm_to_ftm_grad(spin, sampling):
-    flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+def test_flm_to_ftm_grad(spin, sampling, rng):
+    flm, _, thetas = _make_inputs(rng, L_TEST, spin, sampling, reality=False)
 
     def flm_to_ftm(flm):
         return ftm_flm_prim.flm_to_ftm(
@@ -190,8 +189,8 @@ def test_flm_to_ftm_grad(spin, sampling):
 
 @pytest.mark.parametrize("spin", SPIN_TEST)
 @pytest.mark.parametrize("sampling", SAMPLING_TEST)
-def test_ftm_to_flm_grad(spin, sampling):
-    _, ftm, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+def test_ftm_to_flm_grad(spin, sampling, rng):
+    _, ftm, thetas = _make_inputs(rng, L_TEST, spin, sampling, reality=False)
 
     def ftm_to_flm(ftm):
         return ftm_flm_prim.ftm_to_flm(
@@ -211,13 +210,13 @@ def test_ftm_to_flm_grad(spin, sampling):
     check_grads(ftm_to_flm, (ftm,), order=1, modes=("fwd", "rev"))
 
 
-def test_grad_matches_direct_otf_call():
+def test_grad_matches_direct_otf_call(rng):
     """The gradient via our primitive must match the gradient via a manual
     custom_vjp around the same underlying functions, which is the formula
     used by the original code."""
     spin = 1
     sampling = "mw"
-    flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+    flm, _, thetas = _make_inputs(rng, L_TEST, spin, sampling, reality=False)
     glm = jnp.asarray(
         np.random.default_rng(7).standard_normal(samples.ftm_shape(L_TEST, sampling))
         + 1j
@@ -269,11 +268,10 @@ def test_grad_matches_direct_otf_call():
 
 
 @pytest.mark.parametrize("sampling", ["mw", "healpix"])
-def test_flm_to_ftm_vmap_matches_loop(sampling):
+def test_flm_to_ftm_vmap_matches_loop(sampling, rng):
     spin = 0
     nside = 4 if sampling == "healpix" else None
     L = 2 * nside if sampling == "healpix" else L_TEST
-    rng = np.random.default_rng(0)
     batch = 3
     flms = (
         rng.standard_normal((batch,) + samples.flm_shape(L))
@@ -302,11 +300,10 @@ def test_flm_to_ftm_vmap_matches_loop(sampling):
 
 
 @pytest.mark.parametrize("sampling", ["mw", "healpix"])
-def test_ftm_to_flm_vmap_matches_loop(sampling):
+def test_ftm_to_flm_vmap_matches_loop(sampling, rng):
     spin = 0
     nside = 4 if sampling == "healpix" else None
     L = 2 * nside if sampling == "healpix" else L_TEST
-    rng = np.random.default_rng(1)
     batch = 3
     ftms = (
         rng.standard_normal((batch,) + samples.ftm_shape(L, sampling, nside))
@@ -339,11 +336,10 @@ def test_ftm_to_flm_vmap_matches_loop(sampling):
 # ---------------------------------------------------------------------------
 
 
-def test_grad_of_vmap_flm_to_ftm():
+def test_grad_of_vmap_flm_to_ftm(rng):
     spin = 0
     sampling = "mw"
     L = L_TEST
-    rng = np.random.default_rng(2)
     batch = 3
     flms = jnp.asarray(
         rng.standard_normal((batch,) + samples.flm_shape(L))
@@ -397,11 +393,10 @@ def test_grad_of_vmap_flm_to_ftm():
     )
 
 
-def test_vmap_of_grad_ftm_to_flm():
+def test_vmap_of_grad_ftm_to_flm(rng):
     spin = 0
     sampling = "mw"
     L = L_TEST
-    rng = np.random.default_rng(3)
     batch = 3
     ftms = jnp.asarray(
         rng.standard_normal((batch,) + samples.ftm_shape(L, sampling))
@@ -453,8 +448,7 @@ def _spin_valid_flm(rng, L, spin):
 @pytest.mark.parametrize("spin", [0, 1])
 @pytest.mark.parametrize("sampling", ["mw", "mwss", "dh", "gl"])
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_inverse_jax_matches_inverse_numpy(spin, sampling):
-    rng = np.random.default_rng(42)
+def test_inverse_jax_matches_inverse_numpy(spin, sampling, rng):
     L = L_TEST
     flm = _spin_valid_flm(rng, L, spin)
     expected = spherical.inverse_numpy(flm, L, spin=spin, sampling=sampling)
@@ -465,8 +459,7 @@ def test_inverse_jax_matches_inverse_numpy(spin, sampling):
 @pytest.mark.parametrize("spin", [0, 1])
 @pytest.mark.parametrize("sampling", ["mw", "mwss", "dh", "gl"])
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_forward_jax_matches_forward_numpy(spin, sampling):
-    rng = np.random.default_rng(43)
+def test_forward_jax_matches_forward_numpy(spin, sampling, rng):
     L = L_TEST
     flm = _spin_valid_flm(rng, L, spin)
     f = spherical.inverse_numpy(flm, L, spin=spin, sampling=sampling)

--- a/tests/test_ftm_flm_primitive.py
+++ b/tests/test_ftm_flm_primitive.py
@@ -1,0 +1,476 @@
+"""Tests for the custom JAX primitives backing the latitudinal step.
+
+These tests verify:
+
+1. **Numerical equivalence** — the primitive matches a direct call to the
+   underlying ``otf`` function for both directions and several samplings.
+2. **Reverse-mode AD (grad)** — ``check_grads`` confirms the transpose rule
+   produces correct cotangents.
+3. **vmap** — the batcher correctly maps over a leading batch dim and the
+   result equals an explicit Python loop.
+4. **Composed transforms** — ``vmap(grad(...))`` and ``grad(vmap(...))``
+   both produce the same result as a manual loop.
+5. **End-to-end** — ``forward_jax`` / ``inverse_jax`` still match
+   ``forward_numpy`` / ``inverse_numpy`` after the primitive replacement.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.test_util import check_grads
+
+from s2fft.recursions.price_mcewen import generate_precomputes_jax
+from s2fft.sampling import s2_samples as samples
+from s2fft.transforms import _ftm_flm_primitive as ftm_flm_prim
+from s2fft.transforms import otf_recursions as otf
+from s2fft.transforms import spherical
+
+jax.config.update("jax_enable_x64", True)
+
+
+# Light parameter sweep — primitive code paths don't depend on L numerically,
+# so a single small L plus a couple of samplings gives broad coverage cheaply.
+L_TEST = 8
+L_LOWER_TEST = 0
+SPIN_TEST = [-2, 0, 1]
+SAMPLING_TEST = ["mw", "mwss", "dh", "gl"]
+
+
+def _make_inputs(L, spin, sampling, reality, rng_seed=0):
+    rng = np.random.default_rng(rng_seed)
+    flm = (
+        rng.standard_normal(samples.flm_shape(L))
+        + 1j * rng.standard_normal(samples.flm_shape(L))
+    ).astype(np.complex128)
+    ftm = (
+        rng.standard_normal(samples.ftm_shape(L, sampling))
+        + 1j * rng.standard_normal(samples.ftm_shape(L, sampling))
+    ).astype(np.complex128)
+    if reality:
+        flm = flm.real.astype(np.complex128)
+        ftm = ftm.real.astype(np.complex128)
+    thetas = jnp.asarray(samples.thetas(L, sampling))
+    return jnp.asarray(flm), jnp.asarray(ftm), thetas
+
+
+# ---------------------------------------------------------------------------
+# 1. Numerical equivalence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("spin", SPIN_TEST)
+@pytest.mark.parametrize("sampling", SAMPLING_TEST)
+def test_flm_to_ftm_matches_otf(spin, sampling):
+    flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+    expected = otf.inverse_latitudinal_step_jax(
+        flm,
+        thetas,
+        L_TEST,
+        spin,
+        None,
+        sampling,
+        False,
+        precomps=None,
+        spmd=False,
+        L_lower=L_LOWER_TEST,
+    )
+    actual = ftm_flm_prim.flm_to_ftm(
+        flm,
+        thetas,
+        L=L_TEST,
+        spin=spin,
+        nside=None,
+        sampling=sampling,
+        reality=False,
+        spmd=False,
+        L_lower=L_LOWER_TEST,
+        precomps=None,
+    )
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), atol=1e-12)
+
+
+@pytest.mark.parametrize("spin", SPIN_TEST)
+@pytest.mark.parametrize("sampling", SAMPLING_TEST)
+def test_ftm_to_flm_matches_otf(spin, sampling):
+    _, ftm, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+    expected = otf.forward_latitudinal_step_jax(
+        ftm,
+        thetas,
+        L_TEST,
+        spin,
+        None,
+        sampling,
+        False,
+        precomps=None,
+        spmd=False,
+        L_lower=L_LOWER_TEST,
+    )
+    actual = ftm_flm_prim.ftm_to_flm(
+        ftm,
+        thetas,
+        L=L_TEST,
+        spin=spin,
+        nside=None,
+        sampling=sampling,
+        reality=False,
+        spmd=False,
+        L_lower=L_LOWER_TEST,
+        precomps=None,
+    )
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), atol=1e-12)
+
+
+@pytest.mark.parametrize("sampling", SAMPLING_TEST)
+def test_flm_to_ftm_matches_with_explicit_precomps(sampling):
+    spin = 1
+    flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+    precomps = generate_precomputes_jax(
+        L_TEST,
+        spin,
+        sampling,
+        None,
+        forward=False,
+        L_lower=L_LOWER_TEST,
+        betas=thetas,
+    )
+    expected = otf.inverse_latitudinal_step_jax(
+        flm,
+        thetas,
+        L_TEST,
+        spin,
+        None,
+        sampling,
+        False,
+        precomps=precomps,
+        spmd=False,
+        L_lower=L_LOWER_TEST,
+    )
+    actual = ftm_flm_prim.flm_to_ftm(
+        flm,
+        thetas,
+        L=L_TEST,
+        spin=spin,
+        nside=None,
+        sampling=sampling,
+        reality=False,
+        spmd=False,
+        L_lower=L_LOWER_TEST,
+        precomps=precomps,
+    )
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 2. Reverse-mode AD via the transpose rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("spin", SPIN_TEST)
+@pytest.mark.parametrize("sampling", SAMPLING_TEST)
+def test_flm_to_ftm_grad(spin, sampling):
+    flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+
+    def loss(flm):
+        ftm = ftm_flm_prim.flm_to_ftm(
+            flm,
+            thetas,
+            L=L_TEST,
+            spin=spin,
+            nside=None,
+            sampling=sampling,
+            reality=False,
+            spmd=False,
+            L_lower=L_LOWER_TEST,
+            precomps=None,
+        )
+        return jnp.sum(jnp.abs(ftm) ** 2)
+
+    check_grads(loss, (flm,), order=1, modes=("rev",), atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("spin", SPIN_TEST)
+@pytest.mark.parametrize("sampling", SAMPLING_TEST)
+def test_ftm_to_flm_grad(spin, sampling):
+    _, ftm, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+
+    def loss(ftm):
+        flm = ftm_flm_prim.ftm_to_flm(
+            ftm,
+            thetas,
+            L=L_TEST,
+            spin=spin,
+            nside=None,
+            sampling=sampling,
+            reality=False,
+            spmd=False,
+            L_lower=L_LOWER_TEST,
+            precomps=None,
+        )
+        return jnp.sum(jnp.abs(flm) ** 2)
+
+    check_grads(loss, (ftm,), order=1, modes=("rev",), atol=1e-3, rtol=1e-3)
+
+
+def test_grad_matches_direct_otf_call():
+    """The gradient via our primitive must match the gradient via a manual
+    custom_vjp around the same underlying functions, which is the formula
+    used by the original code."""
+    spin = 1
+    sampling = "mw"
+    flm, _, thetas = _make_inputs(L_TEST, spin, sampling, reality=False)
+    glm = jnp.asarray(
+        np.random.default_rng(7).standard_normal(samples.ftm_shape(L_TEST, sampling))
+        + 1j
+        * np.random.default_rng(8).standard_normal(samples.ftm_shape(L_TEST, sampling))
+    )
+
+    def via_primitive(flm):
+        ftm = ftm_flm_prim.flm_to_ftm(
+            flm,
+            thetas,
+            L=L_TEST,
+            spin=spin,
+            nside=None,
+            sampling=sampling,
+            reality=False,
+            spmd=False,
+            L_lower=L_LOWER_TEST,
+            precomps=None,
+        )
+        return jnp.real(jnp.vdot(glm, ftm))
+
+    grad_prim = jax.grad(via_primitive)(flm)
+    # The expected gradient: jax.vjp of inverse_latitudinal_step_jax pulled
+    # back via the analytic transpose (forward_latitudinal_step_jax).
+    expected = otf.forward_latitudinal_step_jax(
+        glm,
+        thetas,
+        L_TEST,
+        spin,
+        None,
+        sampling,
+        False,
+        precomps=None,
+        spmd=False,
+        L_lower=L_LOWER_TEST,
+    )
+    # ``jax.grad`` of a real-valued function of complex arrays returns the
+    # conjugate of the holomorphic gradient. Compare against the conjugate.
+    np.testing.assert_allclose(
+        np.asarray(grad_prim),
+        np.asarray(jnp.conj(expected)),
+        atol=1e-10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. vmap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sampling", ["mw", "healpix"])
+def test_flm_to_ftm_vmap_matches_loop(sampling):
+    spin = 0
+    nside = 4 if sampling == "healpix" else None
+    L = 2 * nside if sampling == "healpix" else L_TEST
+    rng = np.random.default_rng(0)
+    batch = 3
+    flms = (
+        rng.standard_normal((batch,) + samples.flm_shape(L))
+        + 1j * rng.standard_normal((batch,) + samples.flm_shape(L))
+    ).astype(np.complex128)
+    flms = jnp.asarray(flms)
+    thetas = jnp.asarray(samples.thetas(L, sampling, nside))
+
+    def call(flm):
+        return ftm_flm_prim.flm_to_ftm(
+            flm,
+            thetas,
+            L=L,
+            spin=spin,
+            nside=nside,
+            sampling=sampling,
+            reality=False,
+            spmd=False,
+            L_lower=0,
+            precomps=None,
+        )
+
+    vmapped = jax.vmap(call)(flms)
+    looped = jnp.stack([call(flms[i]) for i in range(batch)])
+    np.testing.assert_allclose(np.asarray(vmapped), np.asarray(looped), atol=1e-12)
+
+
+@pytest.mark.parametrize("sampling", ["mw", "healpix"])
+def test_ftm_to_flm_vmap_matches_loop(sampling):
+    spin = 0
+    nside = 4 if sampling == "healpix" else None
+    L = 2 * nside if sampling == "healpix" else L_TEST
+    rng = np.random.default_rng(1)
+    batch = 3
+    ftms = (
+        rng.standard_normal((batch,) + samples.ftm_shape(L, sampling, nside))
+        + 1j * rng.standard_normal((batch,) + samples.ftm_shape(L, sampling, nside))
+    ).astype(np.complex128)
+    ftms = jnp.asarray(ftms)
+    thetas = jnp.asarray(samples.thetas(L, sampling, nside))
+
+    def call(ftm):
+        return ftm_flm_prim.ftm_to_flm(
+            ftm,
+            thetas,
+            L=L,
+            spin=spin,
+            nside=nside,
+            sampling=sampling,
+            reality=False,
+            spmd=False,
+            L_lower=0,
+            precomps=None,
+        )
+
+    vmapped = jax.vmap(call)(ftms)
+    looped = jnp.stack([call(ftms[i]) for i in range(batch)])
+    np.testing.assert_allclose(np.asarray(vmapped), np.asarray(looped), atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 4. vmap composed with grad (the case that broke under custom_vjp / linear_call)
+# ---------------------------------------------------------------------------
+
+
+def test_grad_of_vmap_flm_to_ftm():
+    spin = 0
+    sampling = "mw"
+    L = L_TEST
+    rng = np.random.default_rng(2)
+    batch = 3
+    flms = jnp.asarray(
+        rng.standard_normal((batch,) + samples.flm_shape(L))
+        + 1j * rng.standard_normal((batch,) + samples.flm_shape(L))
+    )
+    thetas = jnp.asarray(samples.thetas(L, sampling))
+
+    def loss(flms):
+        ftms = jax.vmap(
+            lambda flm: ftm_flm_prim.flm_to_ftm(
+                flm,
+                thetas,
+                L=L,
+                spin=spin,
+                nside=None,
+                sampling=sampling,
+                reality=False,
+                spmd=False,
+                L_lower=0,
+                precomps=None,
+            )
+        )(flms)
+        return jnp.sum(jnp.abs(ftms) ** 2)
+
+    # Should not raise; gradient should match a Python-loop reference.
+    grad_via_vmap = jax.grad(loss)(flms)
+
+    def loss_loop(flms):
+        total = 0.0
+        for i in range(batch):
+            ftm = ftm_flm_prim.flm_to_ftm(
+                flms[i],
+                thetas,
+                L=L,
+                spin=spin,
+                nside=None,
+                sampling=sampling,
+                reality=False,
+                spmd=False,
+                L_lower=0,
+                precomps=None,
+            )
+            total = total + jnp.sum(jnp.abs(ftm) ** 2)
+        return total
+
+    grad_via_loop = jax.grad(loss_loop)(flms)
+    np.testing.assert_allclose(
+        np.asarray(grad_via_vmap),
+        np.asarray(grad_via_loop),
+        atol=1e-10,
+    )
+
+
+def test_vmap_of_grad_ftm_to_flm():
+    spin = 0
+    sampling = "mw"
+    L = L_TEST
+    rng = np.random.default_rng(3)
+    batch = 3
+    ftms = jnp.asarray(
+        rng.standard_normal((batch,) + samples.ftm_shape(L, sampling))
+        + 1j * rng.standard_normal((batch,) + samples.ftm_shape(L, sampling))
+    )
+    thetas = jnp.asarray(samples.thetas(L, sampling))
+
+    def per_sample_grad(ftm):
+        return jax.grad(
+            lambda f: jnp.sum(
+                jnp.abs(
+                    ftm_flm_prim.ftm_to_flm(
+                        f,
+                        thetas,
+                        L=L,
+                        spin=spin,
+                        nside=None,
+                        sampling=sampling,
+                        reality=False,
+                        spmd=False,
+                        L_lower=0,
+                        precomps=None,
+                    )
+                )
+                ** 2
+            )
+        )(ftm)
+
+    via_vmap = jax.vmap(per_sample_grad)(ftms)
+    via_loop = jnp.stack([per_sample_grad(ftms[i]) for i in range(batch)])
+    np.testing.assert_allclose(np.asarray(via_vmap), np.asarray(via_loop), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# 5. End-to-end: full forward / inverse spherical transform after the swap
+# ---------------------------------------------------------------------------
+
+
+def _spin_valid_flm(rng, L, spin):
+    """Random flm satisfying the spin condition ``flm[:|s|] == 0``."""
+    flm = (
+        rng.standard_normal(samples.flm_shape(L))
+        + 1j * rng.standard_normal(samples.flm_shape(L))
+    ).astype(np.complex128)
+    flm[: abs(spin)] = 0.0
+    return flm
+
+
+@pytest.mark.parametrize("spin", [0, 1])
+@pytest.mark.parametrize("sampling", ["mw", "mwss", "dh", "gl"])
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_inverse_jax_matches_inverse_numpy(spin, sampling):
+    rng = np.random.default_rng(42)
+    L = L_TEST
+    flm = _spin_valid_flm(rng, L, spin)
+    expected = spherical.inverse_numpy(flm, L, spin=spin, sampling=sampling)
+    actual = spherical.inverse_jax(jnp.asarray(flm), L, spin=spin, sampling=sampling)
+    np.testing.assert_allclose(np.asarray(actual), expected, atol=1e-10)
+
+
+@pytest.mark.parametrize("spin", [0, 1])
+@pytest.mark.parametrize("sampling", ["mw", "mwss", "dh", "gl"])
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_forward_jax_matches_forward_numpy(spin, sampling):
+    rng = np.random.default_rng(43)
+    L = L_TEST
+    flm = _spin_valid_flm(rng, L, spin)
+    f = spherical.inverse_numpy(flm, L, spin=spin, sampling=sampling)
+    expected = spherical.forward_numpy(f, L, spin=spin, sampling=sampling)
+    actual = spherical.forward_jax(jnp.asarray(f), L, spin=spin, sampling=sampling)
+    np.testing.assert_allclose(np.asarray(actual), expected, atol=1e-9)


### PR DESCRIPTION
## Summary
  
  Closes #379.

The latitudinal Wigner-d step in `spherical.inverse_jax` / `spherical.forward_jax` was previously wrapped with `jax.custom_vjp`. While that is sufficient for `jax.grad`, `custom_vjp` does not declare a transpose rule, so `jax.linear_transpose` (and any transform that relies on it — e.g. `jax.linearize`, double-`vjp`, certain `vmap` + autodiff compositions) fails on these transforms even though the operation is linear and has an exact analytical adjoint.

This PR replaces the `custom_vjp` wrapping with two registered JAX primitives, `flm_to_ftm` and `ftm_to_flm`, defined in a new module `s2fft/transforms/_ftm_flm_primitive.py`. Each primitive declares:
  
  - an **abstract eval** for shape/dtype propagation,
  - an **MLIR lowering** that preserves the existing numerics,
  - a **JVP rule** for tangent propagation,
  - an explicit **transpose rule** — the key fix — where the transpose of `flm_to_ftm` is `ftm_to_flm` and vice-versa, exploiting the analytical adjoint,
  - a **batching rule** so `vmap` composes cleanly with autodiff.

The two primitives are wired through the existing `register_primitive` helper already used for the HEALPix CUDA targets, so the registration path is consistent with the rest of the codebase.
  
## Changes

  - `s2fft/transforms/_ftm_flm_primitive.py` *(new)* — primitive definitions, lowerings, JVP / transpose / batching rules.
  - `s2fft/transforms/spherical.py` — `inverse_jax` and `forward_jax` now call the primitives instead of the `custom_vjp`-wrapped helpers; dead `custom_vjp` plumbing removed.
  - `tests/test_ftm_flm_primitive.py` *(new)* — tests covering forward numerics, `jvp`, `vjp`, `linear_transpose`, double-transpose round-trip, and `vmap` interactions.