### PR TITLE
Use `ftm_to_flm` and `flm_to_ftm` primitives in each others transpose rules

### DIFF
--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -158,17 +158,10 @@ def _flm_to_ftm_jvp(primals, tangents, **params):
 
 
 def _flm_to_ftm_transpose(cotangent, flm, thetas, spin, *precomps, **params):
-    # ``flm`` arrives as an UndefinedPrimal; ``thetas``, ``spin`` and
-    # ``precomps`` are concrete residuals. The transpose of the inverse step
-    # is the forward step. We pass ``precomps=None`` so it regenerates the
-    # forward-direction precomps internally (the supplied ones are for the
-    # inverse direction).
-    def fn(c, s, _ignored_p):
-        return otf.forward_latitudinal_step_jax(
-            ftm_in=c, beta_in=thetas, spin=s, precomps=None, **params
-        )
-
-    cot_flm = _apply_with_batching(fn, cotangent, spin, precomps)
+    # The transpose of the flm_to_ftm primitive (applied to the initial flm argument) is
+    # the ftm_to_flm primitive. We do not pass through the supplied (flm_to_ftm) precomps
+    # so these are regenerated internally for the ftm_to_flm primitive.
+    cot_flm = _ftm_to_flm_primitive.bind(cotangent, thetas, spin, **params)
     return (cot_flm, None, None) + (None,) * len(precomps)
 
 
@@ -225,14 +218,11 @@ def _ftm_to_flm_jvp(primals, tangents, **params):
 
 
 def _ftm_to_flm_transpose(cotangent, ftm, thetas, spin, *precomps, **params):
-    # The transpose of the forward step is the inverse step. We pass
-    # ``precomps=None`` so it regenerates the inverse-direction precomps.
-    def fn(c, s, _ignored_p):
-        return otf.inverse_latitudinal_step_jax(
-            flm=c, beta=thetas, spin=s, precomps=None, **params
-        )
-
-    cot_ftm = _apply_with_batching(fn, cotangent, spin, precomps)
+    # cot_ftm = _apply_with_batching(fn, cotangent, spin, precomps)
+    # The transpose of the ftm_to_flm primitive (applied to the initial ftm argument) is
+    # the flm_to_ftm primitive. We do not pass through the supplied (ftm_to_flm) precomps
+    # so these are regenerated internally for the flm_to_ftm primitive.
+    cot_ftm = _flm_to_ftm_primitive.bind(cotangent, thetas, spin, **params)
     return (cot_ftm, None, None) + (None,) * len(precomps)
 
 

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -169,7 +169,7 @@ def _flm_to_ftm_transpose(cotangent, flm, thetas, spin, *precomps, **params):
     # The transpose of the flm_to_ftm primitive (applied to the initial flm argument) is
     # the ftm_to_flm primitive. We do not pass through the supplied (flm_to_ftm) precomps
     # so these are regenerated internally for the ftm_to_flm primitive.
-    cot_flm = _ftm_to_flm_primitive.bind(cotangent, thetas, spin, **params)
+    cot_flm = ftm_to_flm(cotangent, thetas, spin=spin, **params)
     return (cot_flm, None, None) + (None,) * len(precomps)
 
 
@@ -235,7 +235,7 @@ def _ftm_to_flm_transpose(cotangent, ftm, thetas, spin, *precomps, **params):
     # The transpose of the ftm_to_flm primitive (applied to the initial ftm argument) is
     # the flm_to_ftm primitive. We do not pass through the supplied (ftm_to_flm) precomps
     # so these are regenerated internally for the flm_to_ftm primitive.
-    cot_ftm = _flm_to_ftm_primitive.bind(cotangent, thetas, spin, **params)
+    cot_ftm = flm_to_ftm(cotangent, thetas, spin=spin, **params)
     return (cot_ftm, None, None) + (None,) * len(precomps)
 
 

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -224,7 +224,6 @@ def _ftm_to_flm_jvp(primals, tangents, **params):
 
 
 def _ftm_to_flm_transpose(cotangent, ftm, thetas, spin, *precomps, **params):
-    # cot_ftm = _apply_with_batching(fn, cotangent, spin, precomps)
     # The transpose of the ftm_to_flm primitive (applied to the initial ftm argument) is
     # the flm_to_ftm primitive. We do not pass through the supplied (ftm_to_flm) precomps
     # so these are regenerated internally for the flm_to_ftm primitive.

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -179,6 +179,12 @@ _flm_to_ftm_primitive = register_primitive(
     batcher=_flm_to_ftm_batcher,
     jacobian_vector_product=_flm_to_ftm_jvp,
     transpose=_flm_to_ftm_transpose,
+    # While primitive is linear in first argument, we require thetas & spin arguments to
+    # compute linear map (transposed) as function of first argument. JAX assumes either:
+    # (i) all primal arguments not required to compute transpose (when using deflinear),
+    # (ii) primitive is differentiable wrt all primal arguments (when using deflinear2).
+    # As we cannot differentiate wrt integer spin argument we manually define tranpose
+    # rule return None for arguments other than first.
     is_linear=False,
 )
 
@@ -240,6 +246,8 @@ _ftm_to_flm_primitive = register_primitive(
     batcher=_ftm_to_flm_batcher,
     jacobian_vector_product=_ftm_to_flm_jvp,
     transpose=_ftm_to_flm_transpose,
+    # Primitive is linear in first argument but we cannot use JAX deflinear machinery.
+    # See note in comment in _flm_to_ftm_primitive definition for explanation.
     is_linear=False,
 )
 

--- a/s2fft/transforms/_ftm_flm_primitive.py
+++ b/s2fft/transforms/_ftm_flm_primitive.py
@@ -131,7 +131,15 @@ def _batch_primitive(primitive, batched_args, batch_axes, **params):
 def _flm_to_ftm_abstract(
     flm, thetas, spin, *precomps, L, nside, sampling, reality, spmd, L_lower
 ):
-    out_shape = flm.shape[:-_DATA_NDIM] + samples.ftm_shape(L, sampling, nside)
+    # As inverse_latitudinal_step_jax determines shape of first dimension of ftm value
+    # returned by size (of last dimension if batched) of thetas argument instead of
+    # the value returned by samples.ntheta / samples.ftm_shape(...)[0], to allow
+    # for the upsampling performed for MW + MWSS schemes, we cannot use
+    # samples.ftm_shape directly here as might be expected
+    out_shape = flm.shape[:-_DATA_NDIM] + (
+        thetas.shape[-1],
+        samples.ftm_shape(L, sampling, nside)[1],
+    )
     return ShapedArray(out_shape, flm.dtype)
 
 

--- a/tests/test_ftm_flm_primitive.py
+++ b/tests/test_ftm_flm_primitive.py
@@ -203,8 +203,7 @@ def test_ftm_to_flm_grad(spin, sampling, rng):
             precomps=None,
         )
 
-    # TODO: figure out why this fails for MWSS scheme for order=2
-    check_grads(ftm_to_flm, (ftm,), order=1, modes=("fwd", "rev"))
+    check_grads(ftm_to_flm, (ftm,), order=2, modes=("fwd", "rev"))
 
 
 def test_grad_matches_direct_otf_call(rng):


### PR DESCRIPTION
Resolves an issue I noted in https://github.com/astro-informatics/s2fft/pull/380#issuecomment-4578123508 that the `check_grads` gradient check utility was flagging incorrect order 2 gradients for the `ftm_to_flm` primitive when using reverse-mode automatic differentiation.

From a bit more digging and looking at the jaxprs of the `vjp` and `jvp` transforms applied to the primitives, I realised that while for forward-mode differentiation the jaxpr for the `jvp` of the primitives was being expressed in terms of the primitive itself, for reverse-mode differentiation the jaxpr for the `vjp` of the primitives was instead being expanded to the primitives used to define the (transpose) primitive rather than the transpose primitive itself. This means on subsequent applications of `vjp` (or `jvp`) we are differentiating through the underlying primitives, and due to the handling of the pole singularities this appears to introduce non-finite values.

This PR changes the transpose rules for the `ftm_to_flm` and `flm_to_ftm` primitives to instead be defined directly in terms of the other _primitive_ rather than the underlying `inverse_latitudinal_step_jax` and `forward_latitudinal_step_jax` implementations in the `otf_recursions` module. This means JVP and transpose operations over the pair are 'closed' in the sense that arbitrary combinations are expressed directly in terms of the primitives themselves so we can differentiate to any order without autodiffing through the underlying recursive implementations and hitting against issues with pole singularities. This also has the side benefit of removing the need to separately handle batching in the transpose rules.

I also added a note to explain why we are not using `is_linear=True` in `register_primitive` calls as this initially surprised me as primitives are linear in initial `flm` / `ftm` arguments. Having played around a little with trying to use both `deflinear` and `deflinear2` in `jax.interpreters.ad` to avoid explicitly having to define a JVP rule and to allow a simpler transpose definition, it doesn't look like this is easy to do while retaining ability to batch over `spin` and `precomps` arguments, so I have just added a note to remind us why this is the case to avoid similar confusion when looking at this again in future.

@ArtemBasyrov tagging you in case you can take a quick look over this as I think you're probably best placed to check this all makes sense and the change is quite small, but if you don't have capacity to look at this no worries obviously! If you're happy to do so I can add you as a collaborator on the repository so I can explicitly request a review.