### PR TITLE
Fix HEALPix spin!=0 inverse/forward inaccuracy from Wigner-d node

### DIFF
--- a/s2fft/transforms/otf_recursions.py
+++ b/s2fft/transforms/otf_recursions.py
@@ -161,8 +161,16 @@ def inverse_latitudinal_step(
                     axis=-1,
                 )
 
-                bigi = 1.0 / abs(dl_entry[:, L_lower:])
-                lbig = np.log(abs(dl_entry[:, L_lower:]))
+                # Guard against renormalising on an exact node of the Wigner-d
+                # recursion (dl_entry == 0). This occurs at the rational cos(theta)
+                # values of HEALPix rings for spin != 0, where 1/|dl_entry| -> inf
+                # and log|dl_entry| -> -inf would otherwise inject NaNs that are
+                # silently dropped by nansum, losing that mode's contribution.
+                abs_entry = abs(dl_entry[:, L_lower:])
+                nonzero = abs_entry != 0
+                safe_abs = np.where(nonzero, abs_entry, 1.0)
+                bigi = np.where(nonzero, 1.0 / safe_abs, 1.0)
+                lbig = np.where(nonzero, np.log(safe_abs), 0.0)
 
                 dl_iter[0] = np.where(index, bigi * dl_iter[1], dl_iter[0])
                 dl_iter[1] = np.where(index, bigi * dl_entry[:, L_lower:], dl_iter[1])
@@ -341,8 +349,16 @@ def inverse_latitudinal_step_jax(
                     )
                 )
 
-                bigi = 1.0 / abs(dl_entry[:, L_lower:])
-                lbig = jnp.log(abs(dl_entry[:, L_lower:]))
+                # Guard against renormalising on an exact node of the Wigner-d
+                # recursion (dl_entry == 0). This occurs at the rational cos(theta)
+                # values of HEALPix rings for spin != 0, where 1/|dl_entry| -> inf
+                # and log|dl_entry| -> -inf would otherwise inject NaNs that are
+                # silently dropped by nansum, losing that mode's contribution.
+                abs_entry = abs(dl_entry[:, L_lower:])
+                nonzero = abs_entry != 0
+                safe_abs = jnp.where(nonzero, abs_entry, 1.0)
+                bigi = jnp.where(nonzero, 1.0 / safe_abs, 1.0)
+                lbig = jnp.where(nonzero, jnp.log(safe_abs), 0.0)
 
                 dl_iter = dl_iter.at[0].set(
                     jnp.where(index, bigi * dl_iter[1], dl_iter[0])
@@ -578,8 +594,16 @@ def forward_latitudinal_step(
                     axis=-2,
                 )
 
-                bigi = 1.0 / abs(dl_entry[:, L_lower:])
-                lbig = np.log(abs(dl_entry[:, L_lower:]))
+                # Guard against renormalising on an exact node of the Wigner-d
+                # recursion (dl_entry == 0). This occurs at the rational cos(theta)
+                # values of HEALPix rings for spin != 0, where 1/|dl_entry| -> inf
+                # and log|dl_entry| -> -inf would otherwise inject NaNs that are
+                # silently dropped by nansum, losing that mode's contribution.
+                abs_entry = abs(dl_entry[:, L_lower:])
+                nonzero = abs_entry != 0
+                safe_abs = np.where(nonzero, abs_entry, 1.0)
+                bigi = np.where(nonzero, 1.0 / safe_abs, 1.0)
+                lbig = np.where(nonzero, np.log(safe_abs), 0.0)
 
                 dl_iter[0] = np.where(index, bigi * dl_iter[1], dl_iter[0])
                 dl_iter[1] = np.where(index, bigi * dl_entry[:, L_lower:], dl_iter[1])
@@ -780,8 +804,16 @@ def forward_latitudinal_step_jax(
                     )
                 )
 
-                bigi = 1.0 / abs(dl_entry)
-                lbig = jnp.log(abs(dl_entry))
+                # Guard against renormalising on an exact node of the Wigner-d
+                # recursion (dl_entry == 0). This occurs at the rational cos(theta)
+                # values of HEALPix rings for spin != 0, where 1/|dl_entry| -> inf
+                # and log|dl_entry| -> -inf would otherwise inject NaNs that are
+                # silently dropped by nansum, losing that mode's contribution.
+                abs_entry = abs(dl_entry)
+                nonzero = abs_entry != 0
+                safe_abs = jnp.where(nonzero, abs_entry, 1.0)
+                bigi = jnp.where(nonzero, 1.0 / safe_abs, 1.0)
+                lbig = jnp.where(nonzero, jnp.log(safe_abs), 0.0)
 
                 dl_iter = dl_iter.at[0].set(
                     jnp.where(index, bigi * dl_iter[1], dl_iter[0])

--- a/tests/test_spherical_transform.py
+++ b/tests/test_spherical_transform.py
@@ -8,6 +8,7 @@ import torch
 from s2fft.recursions.price_mcewen import generate_precomputes
 from s2fft.sampling import s2_samples as samples
 from s2fft.transforms import spherical
+from s2fft.base_transforms import spherical as base
 
 jax.config.update("jax_enable_x64", True)
 
@@ -94,6 +95,29 @@ def test_transform_inverse_healpix(
     )
 
     np.testing.assert_allclose(np.real(f), np.real(test_data["f_hp"]), atol=1e-14)
+
+
+@pytest.mark.parametrize("nside", nside_to_test)
+@pytest.mark.parametrize("spin", [1, 2])
+@pytest.mark.parametrize("method", ["numpy", "jax"])
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_transform_inverse_healpix_spin(
+    flm_generator: Callable,
+    nside: int,
+    spin: int,
+    method: str,
+):
+    # Regression test for the HEALPix spin != 0 inverse transform. The recursive
+    # (on-the-fly) Wigner-d recursion previously hit exact zero nodes at the
+    # rational cos(theta) values of HEALPix rings, injecting NaNs that nansum
+    # dropped, producing percent-level errors. Validate against the independent
+    # Turok-recursion base transform which samples the same HEALPix grid.
+    sampling = "healpix"
+    L = 2 * nside
+    flm = flm_generator(L=L, spin=spin, reality=False)
+    f = spherical.inverse(flm, L, spin=spin, nside=nside, sampling=sampling, method=method)
+    f_base = base.inverse(flm, L, spin=spin, nside=nside, sampling=sampling)
+    np.testing.assert_allclose(np.asarray(f), f_base, atol=1e-12)
 
 
 @pytest.mark.parametrize("L", L_to_test)


### PR DESCRIPTION
Note: this bug was uncovered and fixed by agentic AI tools, but it is a real non-trivial bug whose fix should be merged. We need sasfe_abs for avoit hitting nans for auto-diff. There is a test added that fails in the current main version, but passes here, so it would be good to keep it. Below is the machine generated description: 

The on-the-fly Price-McEwen Wigner-d recursion renormalises each step by bigi = 1/|dl_entry| and tracks lbig = log|dl_entry|. When an intermediate recursion value dl_entry is exactly zero (a node), bigi becomes inf and lbig becomes -inf, so dl_iter = inf*0 = NaN and the running log-norm goes to -inf. These NaNs are silently dropped by the nansum that accumulates ftm/flm, discarding that mode's contribution and producing percent-level errors.

Exact-zero nodes are essentially never hit by the generic theta samples of mw/mwss/dh/gl sampling, but HEALPix rings sit at rational cos(theta) values that land exactly on nodes for spin != 0, so spin-2 HEALPix transforms carried few-percent pointwise errors (spin-0 was unaffected and existing HEALPix tests only covered spin 0).

Guard the renormalisation so that where dl_entry == 0 we use bigi = 1 and lbig = 0, leaving lrenorm unchanged and setting the normalised value to 0, which is exactly consistent with the recursion bookkeeping. Applied to all four recursion paths (numpy/jax inverse and forward).

Adds a regression test comparing the recursive HEALPix spin-1/2 inverse against the independent Turok-recursion base transform.